### PR TITLE
feat(nextcloud): #DRIV-26 add new route for copying and moving files from nextcloud

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -6,10 +6,7 @@ import fr.openent.nextcloud.security.OwnerFilter;
 import fr.openent.nextcloud.service.DocumentsService;
 import fr.openent.nextcloud.service.ServiceFactory;
 import fr.openent.nextcloud.service.UserService;
-import fr.wseduc.rs.ApiDoc;
-import fr.wseduc.rs.Delete;
-import fr.wseduc.rs.Get;
-import fr.wseduc.rs.Put;
+import fr.wseduc.rs.*;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import io.vertx.core.http.HttpServerRequest;
@@ -59,10 +56,10 @@ public class DocumentsController extends ControllerHelper {
         UserUtils.getUserInfos(eb, request, user ->
                 userService.getUserSession(user.getUserId())
                         .compose(userSession -> documentsService.getFile(userSession, path.replace(" ", "%20")))
-                        .onSuccess(file -> request.response()
+                        .onSuccess(fileResponse -> request.response()
                                 .putHeader("Content-type", contentType + "; charset=utf-8")
                                 .putHeader("Content-Disposition", "attachment; filename=" + fileName)
-                                .end(file))
+                                .end(fileResponse.body()))
                         .onFailure(err -> renderError(request)));
     }
 
@@ -77,14 +74,14 @@ public class DocumentsController extends ControllerHelper {
             UserUtils.getUserInfos(eb, request, user ->
                     userService.getUserSession(user.getUserId())
                             .compose(userSession -> documentsService.getFiles(userSession, path, files))
-                            .onSuccess(file -> {
+                            .onSuccess(fileResponse -> {
                                 String pathName = path.equals("/") ? user.getLogin() : path;
                                 HttpServerResponse resp = request.response();
                                 resp.putHeader("Content-Disposition", "attachment; filename=\"" + pathName + ".zip\"");
                                 resp.putHeader("Content-Type", "application/octet-stream");
                                 resp.putHeader("Content-Description", "File Transfer");
                                 resp.putHeader("Content-Transfer-Encoding", "binary");
-                                resp.end(file);
+                                resp.end(fileResponse.body());
                             })
                             .onFailure(err -> renderError(request)));
         } else {
@@ -144,10 +141,45 @@ public class DocumentsController extends ControllerHelper {
                         .compose(userSession -> {
                             request.resume();
                             return FileHelper.uploadMultipleFiles(Field.FILECOUNT, request, storage, vertx)
-                                    .compose(files -> documentsService.uploadFiles(userSession, files, storage, path));
+                                    .compose(files -> documentsService.uploadFiles(userSession, files, path));
                         })
                         .onSuccess(res -> renderJson(request, res))
-                        .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err))));
+                        .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
 
     }
+
+    @Put("/files/user/:userid/move/workspace")
+    @ApiDoc("Move a file from Nextcloud to ENT workspace")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(OwnerFilter.class)
+    public void moveToWorkspace(HttpServerRequest request) {
+        List<String> listFiles = request.params().getAll(Field.PATH);
+        String parentId = request.params().get(Field.PARENTID);
+        if (!listFiles.isEmpty())
+            UserUtils.getUserInfos(eb, request, user ->
+                userService.getUserSession(user.getUserId())
+                        .compose(userSession -> documentsService.moveDocumentToWorkspace(userSession, user, listFiles, parentId))
+                        .onSuccess(res -> renderJson(request, res))
+                        .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
+        else
+            badRequest(request);
+    }
+
+    @Put("/files/user/:userid/copy/workspace")
+    @ApiDoc("Copy a file from Nextcloud to ENT workspace")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(OwnerFilter.class)
+    public void copyToWorkspace(HttpServerRequest request) {
+        List<String> listFiles = request.params().getAll(Field.PATH);
+        String parentId = request.params().get(Field.PARENTID);
+        if (!listFiles.isEmpty())
+            UserUtils.getUserInfos(eb, request, user ->
+                userService.getUserSession(user.getUserId())
+                        .compose(userSession -> documentsService.copyDocumentToWorkspace(userSession, user, listFiles, parentId))
+                        .onSuccess(res -> renderJson(request, res))
+                        .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
+        else
+            badRequest(request);
+    }
+
 }

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -13,15 +13,24 @@ public class Field {
     public static final String DISPLAYNAMECAMEL = "displayName";
     public static final String EMAIL = "email";
     public static final String PHONE = "phone";
+    public static final String ACTION = "action";
+    public static final String OWNER = "owner";
+    public static final String OWNERNAME = "ownerName";
+    public static final String UNDERSCORE_ID = "_id";
+    public static final String PARENTID = "parentId";
+    public static final String PARENT_ID = "parent_id";
+    public static final String PARENTFOLDERID = "parentFolderId";
     public static final String ADDRESS = "address";
     public static final String USED = "used";
     public static final String QUOTA = "quota";
     public static final String FREE = "free";
+    public static final String APP = "nextcloud";
     public static final String RELATIVE = "relative";
     public static final String TOTAL = "total";
     public static final String KEY = "key";
     public static final String FILECOUNT = "File-Count";
     public static final String VALUE = "value";
+    public static final String LISTFILES = "List-Files";
     public static final String APPPASSWORD = "apppassword";
     public static final String FILENAME = "fileName";
     public static final String FILENAMELOWER = "filename";
@@ -32,6 +41,7 @@ public class Field {
     public static final String DESTINATION = "destination";
     public static final String ERROR = "error";
 
+
     public static final String STATUS = "status";
     public static final String STATUSCODE = "statuscode";
     public static final String MESSAGE = "message";
@@ -41,6 +51,8 @@ public class Field {
     public static final String METADATA = "metadata";
     public static final String CONTENTTRANSFERTENCODING = "content-transfer-encoding";
     public static final String CONTENT_TYPE = "content-type";
+    public static final String CONTENT_DISPOSITION = "Content-Disposition";
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
     public static final String PATH = "path";
     public static final String PATHFILE = "pathFile";
     public static final String DESTPATH = "destPath";

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -2,6 +2,7 @@ package fr.openent.nextcloud.core.constants;
 
 public class Field {
 
+    public static final String ADDFOLDER = "addFolder";
     public static final String DATA = "data";
     public static final String ID = "id";
     public static final String USERID = "userid";
@@ -22,6 +23,8 @@ public class Field {
     public static final String PARENTFOLDERID = "parentFolderId";
     public static final String ADDRESS = "address";
     public static final String USED = "used";
+    public static final String RESULT = "result";
+    public static final String RESULTS = "results";
     public static final String QUOTA = "quota";
     public static final String FREE = "free";
     public static final String APP = "nextcloud";
@@ -66,6 +69,7 @@ public class Field {
 
     // State
     public static final String OK = "OK";
+    public static final String OK_LOWER = "ok";
     public static final String KO = "KO";
 
 

--- a/src/main/java/fr/openent/nextcloud/helper/EbHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/EbHelper.java
@@ -1,0 +1,53 @@
+package fr.openent.nextcloud.helper;
+
+import fr.openent.nextcloud.core.constants.Field;
+import fr.openent.nextcloud.service.impl.DefaultDocumentsService;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+
+public class EbHelper {
+    private static final String WORKSPACE_BUS_ADDRESS = "org.entcore.workspace";
+    private static final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
+
+    /**
+     * Create a folder ine the workspace
+     * @param folder    JsonObject with folder's infos
+     * @param userId    User's identifier
+     * @param userName  User's username
+     * @return          Future with the status of the folder creation
+     */
+    public static Future<JsonObject> createFolder(EventBus eb, JsonObject folder, String userId, String userName) {
+        JsonObject action = new JsonObject()
+                .put(Field.ACTION, "addFolder")
+                .put(Field.NAME, folder.getString("name"))
+                .put(Field.OWNER, userId)
+                .put(Field.OWNERNAME, userName)
+                .put(Field.PARENTFOLDERID, folder.getString("parent_id"));
+        return ebHandling(eb, action);
+    }
+
+    /**
+     * Call event bus with action
+     * @param eb        EventBus
+     * @param action    The action to perform
+     * @return          Future with the body of the response from the eb
+     */
+    private static Future<JsonObject> ebHandling(EventBus eb, JsonObject action) {
+        Promise<JsonObject> promise = Promise.promise();
+        eb.request(WORKSPACE_BUS_ADDRESS, action, message -> {
+            JsonObject body = new JsonObject(message.result().body().toString());
+            if (!message.succeeded() || !"ok".equals(body.getString("status"))) {
+                String messageToFormat = "[Nextcloud@%s::ebHandling] An error occurred when calling document by event bus : %s";
+                PromiseHelper.reject(log, messageToFormat, EbHelper.class.getName(), message, promise);
+            } else {
+                promise.complete(body);
+            }
+        });
+        return promise.future();
+    }
+}

--- a/src/main/java/fr/openent/nextcloud/helper/FileHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/FileHelper.java
@@ -177,7 +177,8 @@ public class FileHelper {
             if (!Field.ERROR.equals(res.getString(Field.STATUS))) {
                 promise.complete(res);
             } else {
-                promise.fail(String.format("[Nextcloud@%s::writeBuffer] Error while storing file to workspace)", FileHelper.class.getName()));
+                String messageToFormat = "[Nextcloud@%s::writeBuffer] Error while storing file to workspace : %s";
+                PromiseHelper.reject(log, messageToFormat, FileHelper.class.getSimpleName(), new Exception(res.getString(Field.ERROR)), promise);
             }
         });
 
@@ -202,7 +203,6 @@ public class FileHelper {
                         String messageToFormat = "[Nextcloud@%s::addDocument] Error while adding document : %s";
                         PromiseHelper.reject(log, messageToFormat, FileHelper.class.getSimpleName(), resDoc, promise);
                     }});
-//            moveFileHandler(promise, user, parentId)
 
         return promise.future();
     }

--- a/src/main/java/fr/openent/nextcloud/helper/MessageResponseHandler.java
+++ b/src/main/java/fr/openent/nextcloud/helper/MessageResponseHandler.java
@@ -1,0 +1,24 @@
+package fr.openent.nextcloud.helper;
+
+import fr.openent.nextcloud.core.constants.Field;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+
+public class MessageResponseHandler {
+    public static Handler<AsyncResult<Message<JsonObject>>> messageJsonObjectHandler(Handler<Either<String, JsonObject>> handler) {
+        return event -> {
+            if (event.succeeded() && Field.OK.equals(event.result().body().getString(Field.STATUS))) {
+                handler.handle(new Either.Right<>(event.result().body().getJsonObject(Field.RESULT)));
+            } else {
+                if (event.failed()) {
+                    handler.handle(new Either.Left<>(event.cause().getMessage()));
+                    return;
+                }
+                handler.handle(new Either.Left<>(event.result().body().getString(Field.MESSAGE)));
+            }
+        };
+    }
+}

--- a/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
@@ -6,7 +6,8 @@ import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.entcore.common.storage.Storage;
+import io.vertx.ext.web.client.HttpResponse;
+import org.entcore.common.user.UserInfos;
 
 import java.util.List;
 
@@ -28,7 +29,7 @@ public interface DocumentsService {
      * @param path          path of nextcloud's user
      * @return  Future containing Buffer of file {@link Buffer}
      */
-    Future<Buffer> getFile(UserNextcloud.TokenProvider userSession, String path);
+    Future<HttpResponse<Buffer>> getFile(UserNextcloud.TokenProvider userSession, String path);
 
     /**
      * download multiple files (.zip given)
@@ -38,7 +39,7 @@ public interface DocumentsService {
      * @param files             List of wanted file to download
      * @return  Future containing Buffer of file {@link Buffer}
      */
-    Future<Buffer> getFiles(UserNextcloud.TokenProvider userSession, String path, List<String> files);
+    Future<HttpResponse<Buffer>> getFiles(UserNextcloud.TokenProvider userSession, String path, List<String> files);
 
     /**
      * Move Document
@@ -61,19 +62,38 @@ public interface DocumentsService {
     /**
      * upload file
      *  @param user         User session token
-     *  @param storage      Storage manager
      *  @param file         Data about the file to upload
      *  @param path         Path where files will be uploaded on the nextcloud
      */
-    Future<JsonObject> uploadFile(UserNextcloud.TokenProvider user, Storage storage, Attachment file, String path);
+    Future<JsonObject> uploadFile(UserNextcloud.TokenProvider user, Attachment file, String path);
 
     /**
      * upload files
      *  @param userSession      User session
      *  @param files            List of files to upload
-     *  @param storage          Storage manager
      *  @param path             Final path on Nextcloud
      *  @return                 Future of uploaded files
      */
-    Future<JsonArray> uploadFiles(UserNextcloud.TokenProvider userSession, List<Attachment> files, Storage storage, String path);
+    Future<JsonArray> uploadFiles(UserNextcloud.TokenProvider userSession, List<Attachment> files, String path);
+
+
+    /**
+     * Copy all the files listed in the filesPath from nextcloud to local.
+     * @param userSession       User session
+     * @param user              User infos
+     * @param filesPath         Path of all the files to move
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future Json with the infos about every move
+     */
+    Future<JsonObject> copyDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
+
+    /**
+     * Move all the files listed in the filesPath from nextcloud to local.
+     * @param userSession       User session
+     * @param user              User infos
+     * @param filesPath         Path of all the files to move
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future Json with the infos about every move
+     */
+    Future<JsonObject> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
 }

--- a/src/main/java/fr/openent/nextcloud/service/ServiceFactory.java
+++ b/src/main/java/fr/openent/nextcloud/service/ServiceFactory.java
@@ -8,6 +8,8 @@ import fr.wseduc.mongodb.MongoDb;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.ext.web.client.WebClient;
+import org.entcore.common.bus.WorkspaceHelper;
+import org.entcore.common.folders.FolderManager;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.sql.Sql;
 import org.entcore.common.storage.Storage;
@@ -51,6 +53,10 @@ public class ServiceFactory {
 
     public Storage storage() {
         return this.storage;
+    }
+
+    public WorkspaceHelper workspaceHelper() {
+        return new WorkspaceHelper(eventBus(), storage);
     }
 
     public NextcloudConfig nextcloudConfig() {return this.nextcloudConfig;}

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -21,7 +21,9 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.codec.BodyCodec;
+import org.entcore.common.bus.WorkspaceHelper;
 import org.entcore.common.storage.Storage;
+import org.entcore.common.user.UserInfos;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -30,13 +32,16 @@ public class DefaultDocumentsService implements DocumentsService {
     private final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
     private final WebClient client;
     private final NextcloudConfig nextcloudConfig;
-
+    private final Storage storage;
+    private final WorkspaceHelper workspaceHelper;
     private static final String DOWNLOAD_ENDPOINT = "/index.php/apps/files/ajax/download.php";
 
 
     public DefaultDocumentsService(ServiceFactory serviceFactory) {
         this.client = serviceFactory.webClient();
         this.nextcloudConfig = serviceFactory.nextcloudConfig();
+        this.storage = serviceFactory.storage();
+        this.workspaceHelper = serviceFactory.workspaceHelper();
     }
     
     /**
@@ -127,8 +132,8 @@ public class DefaultDocumentsService implements DocumentsService {
     }
 
     @Override
-    public Future<Buffer> getFile(UserNextcloud.TokenProvider userSession, String path) {
-        Promise<Buffer> promise = Promise.promise();
+    public Future<HttpResponse<Buffer>> getFile(UserNextcloud.TokenProvider userSession, String path) {
+        Promise<HttpResponse<Buffer>> promise = Promise.promise();
         this.client.getAbs(nextcloudConfig.host() + nextcloudConfig.webdavEndpoint() + "/" +
                         userSession.userId() + (path != null ? "/" + path : "" ))
                 .basicAuthentication(userSession.userId(), userSession.token())
@@ -142,7 +147,7 @@ public class DefaultDocumentsService implements DocumentsService {
      * @param   responseAsync   HttpResponse of string depending on its state {@link AsyncResult}
      * @param   promise         Promise that could be completed or fail sending {@link Buffer}
      */
-    private void proceedGetFile(AsyncResult<HttpResponse<Buffer>> responseAsync, Promise<Buffer> promise) {
+    private void proceedGetFile(AsyncResult<HttpResponse<Buffer>> responseAsync, Promise<HttpResponse<Buffer>> promise) {
         if (responseAsync.failed()) {
             String messageToFormat = "[Nextcloud@%s::proceedGetFile] An error has occurred during fetching endpoint : %s";
             PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), responseAsync, promise);
@@ -152,14 +157,14 @@ public class DefaultDocumentsService implements DocumentsService {
                 String messageToFormat = "[Nextcloud@%s::proceedGetFile] Response status is not a HTTP 200 : %s : %s";
                 HttpResponseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), response, promise);
             } else {
-                promise.complete(response.body());
+                promise.complete(response);
             }
         }
     }
 
     @Override
-    public Future<Buffer> getFiles(UserNextcloud.TokenProvider userSession, String path, List<String> files) {
-        Promise<Buffer> promise = Promise.promise();
+    public Future<HttpResponse<Buffer>> getFiles(UserNextcloud.TokenProvider userSession, String path, List<String> files) {
+        Promise<HttpResponse<Buffer>> promise = Promise.promise();
         this.client.getAbs(nextcloudConfig.host() + DOWNLOAD_ENDPOINT)
                 .basicAuthentication(userSession.userId(), userSession.token())
                 .addQueryParam(Field.DIR, path)
@@ -266,12 +271,11 @@ public class DefaultDocumentsService implements DocumentsService {
      * Upload multiple files to the nextcloud
      * @param userSession      User session
      * @param files            List of files to upload
-     * @param storage          Storage manager
      * @param path             Final path on Nextcloud
      * @return                 Future JsonArray with data on the uploaded files
      */
     @Override
-    public Future<JsonArray> uploadFiles(UserNextcloud.TokenProvider userSession, List<Attachment> files, Storage storage, String path) {
+    public Future<JsonArray> uploadFiles(UserNextcloud.TokenProvider userSession, List<Attachment> files, String path) {
         Promise<JsonArray> promise = Promise.promise();
         Future<JsonObject> current = Future.succeededFuture();
         JsonArray stateUploadedFiles = new JsonArray();
@@ -280,7 +284,7 @@ public class DefaultDocumentsService implements DocumentsService {
                 if (res != null) {
                     stateUploadedFiles.add(res);
                 }
-                return this.uploadFile(userSession, storage, file, path);
+                return this.uploadFile(userSession, file, path);
             });
         }
         current
@@ -296,14 +300,280 @@ public class DefaultDocumentsService implements DocumentsService {
     }
 
     /**
+     * Copy all the files listed in the filesPath from nextcloud to workspace.
+     * @param userSession       User session
+     * @param user              User infos
+     * @param filesPath         Path of all the files to move
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future Json with the infos about every copy
+     */
+    public Future<JsonObject> copyDocumentToWorkspace(UserNextcloud.TokenProvider userSession,
+                                                      UserInfos user,
+                                                      List<String> filesPath,
+                                                      String parentId) {
+        Promise<JsonObject> promise = Promise.promise();
+        Future<JsonObject> current = Future.succeededFuture();
+
+        JsonObject result = new JsonObject();
+        for (String file : filesPath) {
+            current = current.compose(v -> copyToWorkspace(userSession, user, file, result, parentId));
+        }
+        current.onSuccess(res -> promise.complete(result))
+                .onFailure(err -> {
+                    String messageToFormat = "[Nextcloud@%s::copyDocumentToWorkspace] An error has occurred during copy : %s";
+                    PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);
+
+                });
+
+        return promise.future();
+    }
+
+    /**
+     * Move all the files listed in the filesPath from nextcloud to workspace.
+     * @param userSession       User session
+     * @param user              User infos
+     * @param filesPath         Path of all the files to move
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future Json with infos about every move
+     */
+    @Override
+    public Future<JsonObject> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession,
+                                                      UserInfos user,
+                                                      List<String> filesPath,
+                                                      String parentId) {
+        Promise<JsonObject> promise = Promise.promise();
+        Future<JsonObject> current = Future.succeededFuture();
+        JsonObject result = new JsonObject();
+        for (String file : filesPath) {
+            current = current.compose(v -> moveToWorkspace(userSession, user, file, result, parentId));
+        }
+        current.onSuccess(res -> promise.complete(result))
+                .onFailure(err -> {
+                    String messageToFormat = "[Nextcloud@%s::moveDocumentToWorkspace] An error has occurred while moving documents : %s";
+                    PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);
+                });
+        return promise.future();
+    }
+
+    /** Copy one document from Nextcloud to Workspace
+     * @param userSession       User session
+     * @param user              User infos
+     * @param file              Path of the file you want to move
+     * @param result            Json where status of move is stored
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future Json with the infos about the copy
+     */
+    private Future<JsonObject> copyToWorkspace(UserNextcloud.TokenProvider userSession,
+                                               UserInfos user,
+                                               String file,
+                                               JsonObject result,
+                                               String parentId) {
+        Promise<JsonObject> promiseResult = Promise.promise();
+        //The listFiles function here is called to gather data on one specific file.
+        listFiles(userSession, file)
+                .onSuccess(fileInfo -> {
+                    if (!fileInfo.isEmpty()) {
+                        JsonObject resJson = fileInfo.getJsonObject(0);
+                        if (!resJson.containsKey(Field.DISPLAYNAME) || resJson.getString(Field.DISPLAYNAME).equals("")
+                                || !resJson.containsKey(Field.ISFOLDER)) {
+                            String messageToFormat = "[Nextcloud@%s::copyToWorkspace] An error has occurred while retrieving data from file : %s";
+                            PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), new Exception("Missing arguments"), promiseResult);
+                            return;
+                        }
+                        if (Boolean.FALSE.equals(fileInfo.getJsonObject(0).getBoolean(Field.ISFOLDER))) {
+                            storeFileWorkspace(userSession, user, fileInfo.getJsonObject(0).getString(Field.DISPLAYNAME), parentId).onComplete(status -> {
+                                if (status.succeeded()) {
+                                    result.put(file, status.result());
+                                }
+                                else {
+                                    result.put(file, status.cause().getMessage());
+                                }
+                                promiseResult.complete();
+                            });
+                        }
+                        else {
+                            //TODO Gérer le cas d'import d'un dossier
+                            log.error("import.directory.not.handled");
+                            result.put(file, "import.directory.not.handled");
+                            promiseResult.complete();
+                        }
+                    }
+                    else {
+                        result.put(file, "nextcloud.server.file.no.exist");
+                        promiseResult.complete();
+                    }
+
+                })
+                .onFailure(err -> {
+                    String messageToFormat = "[Nextcloud@%s::copyToWorkspace] An error has occurred while retrieving data from file : %s";
+                    PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promiseResult);
+                });
+        return promiseResult.future();
+
+    }
+
+    /** Move one document from Nextcloud to Workspace
+     * @param userSession       User session
+     * @param user              User infos
+     * @param file              Path of the file you want to move
+     * @param result            Json where status of move is stored
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future Json with the infos about the move
+     */
+    private Future<JsonObject> moveToWorkspace(UserNextcloud.TokenProvider userSession,
+                                               UserInfos user,
+                                               String file,
+                                               JsonObject result,
+                                               String parentId) {
+        Promise<JsonObject> promiseResult = Promise.promise();
+        //The listFiles function here is called to gather data on one specific file.
+        listFiles(userSession, file)
+                .onSuccess(fileInfo -> {
+                    if (!fileInfo.isEmpty()) {
+                        JsonObject resJson = fileInfo.getJsonObject(0);
+
+                        if (!resJson.containsKey(Field.DISPLAYNAME) || resJson.getString(Field.DISPLAYNAME).equals("")
+                                || !resJson.containsKey(Field.ISFOLDER)) {
+                            String messageToFormat = "[Nextcloud@%s::moveToWorkspace] An error has occurred while retrieving data from file : %s";
+                            PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), new Exception("Missing arguments"), promiseResult);
+                            return;
+                        }
+                        if (Boolean.FALSE.equals(fileInfo.getJsonObject(0).getBoolean(Field.ISFOLDER))) {
+                            retrieveAndDeleteFile(userSession, user, fileInfo.getJsonObject(0).getString(Field.DISPLAYNAME), parentId)
+                                    .onComplete(status -> {
+                                if (status.succeeded()) {
+                                    result.put(file, status.result());
+                                } else {
+                                    result.put(file, status.cause().getMessage());
+                                }
+                                promiseResult.complete();
+                            });
+                        } else {
+                            //TODO Gérer le cas d'import d'un dossier
+                            log.error("import.directory.not.handled");
+                            result.put(file, "import.directory.not.handled");
+                            promiseResult.complete();
+                        }
+                    } else {
+                        result.put(file, "nextcloud.server.file.no.exist");
+                        promiseResult.complete();
+                    }
+                })
+                .onFailure(err -> {
+                    String messageToFormat = "[Nextcloud@%s::moveToWorkspace] An error has occurred while retrieving data from file : %s";
+                    PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promiseResult);
+                });
+        return promiseResult.future();
+    }
+
+
+
+    /**
+     * Copy a file from Nextcloud server to workspace and then delete it from nextcloud
+     * @param userSession       User session
+     * @param user              User infos
+     * @param filePath          Path of the file on nextcloud server
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future with the status of the action
+     */
+    private Future<JsonObject> retrieveAndDeleteFile(UserNextcloud.TokenProvider userSession, UserInfos user, String filePath, String parentId) {
+        Promise<JsonObject> promise = Promise.promise();
+        storeFileWorkspace(userSession, user, filePath, parentId)
+                .compose(res -> {promise.complete(res);
+                    return deleteDocument(userSession, filePath);
+                })
+                .onFailure(err -> {
+                    String messageToFormat = "[Nextcloud@%s::retrieveAndDeleteFile] An error has occurred during retrieving" + "" +
+                            "and deleting document document(s) : %s";
+                    PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);
+                });
+        return promise.future();
+    }
+
+    /**
+     * Retrieve file from user's Nextcloud space and store it in his ENT workspace
+     * @param userSession       User session
+     * @param user              User infos
+     * @param filePath          Path of the file on nextcloud server
+     * @param parentId          Identifier of the previous folder if moving in a folder
+     * @return                  Future with the status of the action
+     */
+    private Future<JsonObject> storeFileWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, String filePath, String parentId) {
+        Promise<JsonObject> promise = Promise.promise();
+
+        getFile(userSession, filePath)
+                .compose(buffer ->
+                        FileHelper.writeBuffer(storage, buffer.bodyAsBuffer(), buffer.headers().get(Field.CONTENT_TYPE_HEADER), filePath)
+                )
+                .compose(writeInfo -> {
+                    writeInfo.put(Field.PARENTID, parentId);
+                    return FileHelper.addFileReference(writeInfo, user, filePath, workspaceHelper);
+                })
+                .compose(resDoc -> moveIfNeeded(workspaceHelper, user, parentId, resDoc))
+                .onSuccess(promise::complete)
+                .onFailure(err -> {
+                    String messageToFormat = "[Nextcloud@%s::storeFileWorkspace] Error while storing file : %s";
+                    PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);
+                });
+        return promise.future();
+    }
+
+
+
+    /**
+     * Check if the new file need to be moved under a parent folder and do it if the answer is yes
+     * @param user          User infos
+     * @param parentId      Identifier of the previous folder if moving in a folder
+     * @return              Future with the status of the action
+     */
+    private Future<JsonObject> moveIfNeeded(WorkspaceHelper workspaceHelper, UserInfos user, String parentId, JsonObject resDoc) {
+        Promise<JsonObject> promise = Promise.promise();
+        if (parentId != null) {
+            if (!resDoc.containsKey(Field.UNDERSCORE_ID)) {
+                String messageToFormat = "[Nextcloud@%s::moveIfNeeded] An error has occurred during moving document(s) : %s";
+                PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), new Exception("Missing return ID"), promise);
+                return promise.future();
+            }
+            moveDocumentUnderParent(workspaceHelper, resDoc.getString(Field.UNDERSCORE_ID), parentId, user)
+                    .onSuccess(promise::complete)
+                    .onFailure(res -> {
+                        String messageToFormat = "[Nextcloud@%s::moveIfNeeded] An error has occurred during moving document(s) : %s";
+                        PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), res, promise);
+                    });
+        } else {
+            promise.complete(new JsonObject().put(Field.STATUS, resDoc.getString(Field.STATUS)));
+        }
+        return promise.future();
+    }
+
+    /**
+     * Move a file under a folder in the workspace, the file and the folder need to exist
+     * @param workspaceHelper   Help to manage properly workspace
+     * @param id                File identifier
+     * @param parentId          Parent folder Identifier
+     * @param user              User infos
+     * @return                  Future with the status of the move
+     */
+    private Future<JsonObject> moveDocumentUnderParent(WorkspaceHelper workspaceHelper, String id, String parentId, UserInfos user) {
+        Promise<JsonObject> promise = Promise.promise();
+        workspaceHelper.moveDocument(id, parentId, user, moveStatus -> {
+                    if (moveStatus.failed()) {
+                        String messageToFormat = "[Nextcloud@%s::moveDocumentUnderParent] Error while moving document under parent folder : %s";
+                        PromiseHelper.reject(log, messageToFormat, FileHelper.class.getName(), new Exception("parent.folder.not.exist"), promise);
+                    } else
+                        promise.complete(new JsonObject().put(Field.STATUS, "OK"));
+                });
+        return promise.future();
+    }
+
+    /**
      * upload file
      *  @param user         User session token
-     *  @param storage      Storage manager
      *  @param file         Data about the file to upload
      *  @param path         Path where files will be uploaded on the nextcloud
      */
     @Override
-    public Future<JsonObject> uploadFile(UserNextcloud.TokenProvider user, Storage storage, Attachment file, String path) {
+    public Future<JsonObject> uploadFile(UserNextcloud.TokenProvider user, Attachment file, String path) {
         //Final path on the nextcloud server
         String finalPath = (path != null ? path + "/" : "" ) + file.metadata().filename();
         Promise<JsonObject> promise = Promise.promise();


### PR DESCRIPTION
## Describe your changes
Adding two new routes to API. The first one will be used to move a file from Nextcloud to workspace and the second one will be used to copy a file from Nextcloud to workspace. Nextcloud and Workspace need to belong to the same user.
## Checklist tests
Both of following routes tested with Postman.
[ PUT ] /files/user/:userid/copy/workspace
[ PUT ] /files/user/:userid/move/workspace
## Issue ticket number and link
[ DRIV-26 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-26
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequences regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequence feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)