### PR TITLE
fix(list): fixing bad request due to not encoded spaces in url

### DIFF
--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -55,7 +55,7 @@ public class DefaultDocumentsService implements DocumentsService {
     public Future<JsonArray> listFiles(UserNextcloud.TokenProvider userSession, String path) {
         Promise<JsonArray> promise = Promise.promise();
         this.client.rawAbs(NextcloudHttpMethod.PROPFIND.method(), nextcloudConfig.host() +
-                        nextcloudConfig.webdavEndpoint() + "/" + userSession.userId() + (path != null ? "/" + path : "" ))
+                        nextcloudConfig.webdavEndpoint() + "/" + userSession.userId() + (path != null ? "/" + path.replace(" ", "%20") : "" ))
                 .basicAuthentication(userSession.userId(), userSession.token())
                 .as(BodyCodec.string(StandardCharsets.UTF_8.toString()))
                 .sendBuffer(Buffer.buffer(getListFilesPropsBody()), responseAsync -> proceedListFiles(responseAsync, promise));


### PR DESCRIPTION
## Describe your changes
Listing file was ended up in bad request due to space in the url in backend. Fix was to replace space by %20 before calling nextcloud API.
## Checklist tests
Tested with postman, no more bad request.
## Issue ticket number and link
No ticket.
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

