### PR TITLE
feat: #DRIV-38 add drag file nextcloud to workspace

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -155,7 +155,7 @@ public class DocumentsController extends ControllerHelper {
     public void moveToWorkspace(HttpServerRequest request) {
         List<String> listFiles = request.params().getAll(Field.PATH);
         String parentId = request.params().get(Field.PARENTID);
-        if (!listFiles.isEmpty())
+        if (Boolean.FALSE.equals(listFiles.isEmpty()))
             UserUtils.getUserInfos(eb, request, user ->
                 userService.getUserSession(user.getUserId())
                         .compose(userSession -> documentsService.moveDocumentToWorkspace(userSession, user, listFiles, parentId))

--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -113,4 +113,38 @@ describe('NextcloudService', () => {
 
         done();
     });
+
+    it('Test Put moving document to nextcloud to workspace should have paths appeared in URL request', done => {
+        const mock = new MockAdapter(axios);
+        const data = {response: true};
+
+        const userId = "userId";
+        const paths = ["path", "path1", "path2"];
+        const parentId = "myParentId";
+
+        let spy = jest.spyOn(axios, "put");
+        mock.onPut('/nextcloud/files/user/userId/move/workspace?path=path&path=path1&path=path2&parentId=myParentId')
+            .reply(200, data);
+
+        nextcloudService.moveDocumentNextcloudToWorkspace(userId, paths, parentId).then(() => {
+            expect(spy).toHaveBeenCalledWith( '/nextcloud/files/user/userId/move/workspace?path=path&path=path1&path=path2&parentId=myParentId');
+            done();
+        });
+    });
+
+    it('Test Put moving document to nextcloud to workspace should have paths appeared in URL request without parentId', done => {
+        const mock = new MockAdapter(axios);
+        const data = {response: true};
+
+        const userId = "userId";
+        const paths = ["path", "path1", "path2"];
+
+        let spy = jest.spyOn(axios, "put");
+        mock.onPut('/nextcloud/files/user/userId/move/workspace?path=path&path=path1&path=path2').reply(200, data);
+
+        nextcloudService.moveDocumentNextcloudToWorkspace(userId, paths).then(() => {
+            expect(spy).toHaveBeenCalledWith( '/nextcloud/files/user/userId/move/workspace?path=path&path=path1&path=path2');
+            done();
+        });
+    });
 });

--- a/src/main/resources/public/ts/services/nextcloud-event.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud-event.service.ts
@@ -9,10 +9,10 @@ export class NextcloudEventService {
     // sending document observable
     private documentSubject = new Subject<{parentDocument: SyncDocument, documents: Array<SyncDocument>}>();
 
-    private contentContext: any;
+    private contentContext: SyncDocument;
 
     constructor() {
-        this.contentContext = {};
+        this.contentContext = null;
     }
 
     sendDocuments(documents: {parentDocument: SyncDocument, documents: Array<SyncDocument>}): void {
@@ -31,11 +31,11 @@ export class NextcloudEventService {
         return this.openFolderSubject.asObservable();
     }
 
-    getContentContext(): void {
+    getContentContext(): SyncDocument {
         return this.contentContext;
     }
 
-    setContentContext(content: any): void {
+    setContentContext(content: SyncDocument): void {
         this.contentContext = content;
     }
 }

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -6,6 +6,8 @@ export interface INextcloudService {
     listDocument(userid: string, path?: string): Promise<Array<SyncDocument>>;
     uploadDocuments(userid: string, files: Array<File>): Promise<AxiosResponse>;
     moveDocument(userid: string, path: string, destPath: string): Promise<AxiosResponse>;
+    moveDocumentNextcloudToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<AxiosResponse>;
+    moveDocumentWorkspaceToCloud(userid: string, ids: Array<string>, cloudDocumentName: string): Promise<AxiosResponse>;
     deleteDocuments(userid: string, path: Array<string>): Promise<AxiosResponse>;
     getFile(userid: string, fileName: string, path: string, contentType: string): string;
     getFiles(userid: string, path: string, files: Array<string>): string;
@@ -31,6 +33,20 @@ export const nextcloudService: INextcloudService = {
     moveDocument: (userid: string, path: string, destPath: string): Promise<AxiosResponse> => {
         const urlParam: string = `?path=${path}&destPath=${destPath}`
         return http.put(`/nextcloud/files/user/${userid}/move${urlParam}`);
+    },
+
+    moveDocumentNextcloudToWorkspace: (userid: string, paths: Array<string>, parentId?: string): Promise<AxiosResponse> => {
+        let urlParams: URLSearchParams = new URLSearchParams();
+        paths.forEach((path: string) => urlParams.append('path', path));
+        const parentIdParam: string = parentId ? `&parentId=${parentId}` : '';
+        return http.put(`/nextcloud/files/user/${userid}/move/workspace?${urlParams}${parentIdParam}`);
+    },
+
+    moveDocumentWorkspaceToCloud: (userid: string, ids: Array<string>, cloudDocumentName: string): Promise<AxiosResponse> => {
+        let urlParams: URLSearchParams = new URLSearchParams();
+        ids.forEach((path: string) => urlParams.append('id', path));
+        const parentDocumentNameParam: string = cloudDocumentName ? `&parentName=${cloudDocumentName}` : '';
+        return http.put(`/nextcloud/files/user/${userid}/workspace/move/cloud?${urlParams}${parentDocumentNameParam}`);
     },
 
     deleteDocuments(userid: string, paths: Array<string>): Promise<AxiosResponse> {

--- a/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
+++ b/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
@@ -1,3 +1,6 @@
+import {angular, Folder, workspace} from "entcore";
+import models = workspace.v2.models;
+
 export class WorkspaceEntcoreUtils {
 
     static $ENTCORE_WORKSPACE: string = `div[data-ng-include="'folder-content'"]`;
@@ -34,5 +37,30 @@ export class WorkspaceEntcoreUtils {
         const contentEmptyScreenQuery: string = 'div .toggle-buttons-spacer .emptyscreen';
         Array.from(document.querySelectorAll(contentEmptyScreenQuery))
             .forEach((elem: Element) => (<HTMLElement>elem).style.display =  state ? "flex" : "none");
+    }
+
+    /**
+     * Fetch workspace controller scope
+     */
+    static workspaceScope(): ng.IScope {
+        return angular.element(document.getElementsByClassName("workspace-app")).scope();
+    }
+
+    /**
+     * Update fetch folder content via workspace controller
+     * @param folder folder from workspace controller
+     */
+    static updateWorkspaceDocuments(folder: any | models.Element): void {
+        if (folder && folder instanceof models.Element) {
+            if ("tree" in folder) {
+                WorkspaceEntcoreUtils.workspaceScope()['onTreeInit'](() =>
+                    WorkspaceEntcoreUtils.workspaceScope()['setCurrentTree'](folder['tree']['filter'])
+                )
+            } else if (folder._id && folder.eType === "folder") {
+                WorkspaceEntcoreUtils.workspaceScope()['onTreeInit'](() =>
+                    WorkspaceEntcoreUtils.workspaceScope()['openFolderById'](folder._id)
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes

Depuis l'espace doc, on peut glisser et déposer un document depuis le nextcloud dans n'importe quel dossier dans "mes documents personnels"

En faisant cette action, on supprime le document qu'on a glissé et déposé dans le nextcloud (étant donné qu'on fait un déplacement)

Un fix sur le comportement de la sélection des documents ont été fait également

## Checklist tests

- [x] drag le document de nextcloud et le mettre dans un document
- [x] vérifier que le document dans le nextcloud a disparu une fois terminé
- [x] vérifier que dans mes documents perso', on a bien le document qu'on a déplacé


## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/DRIV-38

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

