### PR TITLE
feat: #DRIV-19 add drag file workspace to nextcloud

### DIFF
--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -1,7 +1,8 @@
-import axios from 'axios';
+import axios, {AxiosResponse} from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {nextcloudService} from '../nextcloud.service';
 import {IDocumentResponse} from "../../models";
+import http from "axios";
 
 describe('NextcloudService', () => {
     it('Test listDocument method', done => {
@@ -147,4 +148,44 @@ describe('NextcloudService', () => {
             done();
         });
     });
+
+
+    it('Test Put moving document workspace to nextcloud should have paths appeared in URL request with cloud name document', done => {
+        const mock = new MockAdapter(axios);
+
+        const userId = "userId";
+        const ids = ["899de998-af86-4feb-99dc-af86dc8fa57e", "fb3109af-d315-4614-a2e8-239b233cbd4c", "3475ed1a-2345-4558-a6dc-515c331eb11d"];
+        const cloudDocumentName = "Documents/test";
+
+        const expectedEndpoint: string = '/nextcloud/files/user/userId/workspace/move/cloud' +
+            '?id=899de998-af86-4feb-99dc-af86dc8fa57e&id=fb3109af-d315-4614-a2e8-239b233cbd4c&id=3475ed1a-2345-4558-a6dc-515c331eb11d' +
+            '&parentName=Documents/test';
+
+        let spy = jest.spyOn(axios, "put");
+        mock.onPut(expectedEndpoint).reply(200);
+
+        nextcloudService.moveDocumentWorkspaceToCloud(userId, ids, cloudDocumentName).then(() => {
+            expect(spy).toHaveBeenCalledWith(expectedEndpoint);
+            done();
+        });
+    });
+
+    it('Test Put moving document workspace to nextcloud should have paths appeared in URL request without cloud name document', done => {
+        const mock = new MockAdapter(axios);
+
+        const userId = "userId";
+        const ids = ["899de998-af86-4feb-99dc-af86dc8fa57e", "fb3109af-d315-4614-a2e8-239b233cbd4c", "3475ed1a-2345-4558-a6dc-515c331eb11d"];
+
+        const expectedEndpoint: string = '/nextcloud/files/user/userId/workspace/move/cloud' +
+            '?id=899de998-af86-4feb-99dc-af86dc8fa57e&id=fb3109af-d315-4614-a2e8-239b233cbd4c&id=3475ed1a-2345-4558-a6dc-515c331eb11d';
+
+        let spy = jest.spyOn(axios, "put");
+        mock.onPut(expectedEndpoint).reply(200);
+
+        nextcloudService.moveDocumentWorkspaceToCloud(userId, ids).then(() => {
+            expect(spy).toHaveBeenCalledWith(expectedEndpoint);
+            done();
+        });
+    });
+
 });

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -7,7 +7,7 @@ export interface INextcloudService {
     uploadDocuments(userid: string, files: Array<File>): Promise<AxiosResponse>;
     moveDocument(userid: string, path: string, destPath: string): Promise<AxiosResponse>;
     moveDocumentNextcloudToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<AxiosResponse>;
-    moveDocumentWorkspaceToCloud(userid: string, ids: Array<string>, cloudDocumentName: string): Promise<AxiosResponse>;
+    moveDocumentWorkspaceToCloud(userid: string, ids: Array<string>, cloudDocumentName?: string): Promise<AxiosResponse>;
     deleteDocuments(userid: string, path: Array<string>): Promise<AxiosResponse>;
     getFile(userid: string, fileName: string, path: string, contentType: string): string;
     getFiles(userid: string, path: string, files: Array<string>): string;
@@ -42,7 +42,7 @@ export const nextcloudService: INextcloudService = {
         return http.put(`/nextcloud/files/user/${userid}/move/workspace?${urlParams}${parentIdParam}`);
     },
 
-    moveDocumentWorkspaceToCloud: (userid: string, ids: Array<string>, cloudDocumentName: string): Promise<AxiosResponse> => {
+    moveDocumentWorkspaceToCloud: (userid: string, ids: Array<string>, cloudDocumentName?: string): Promise<AxiosResponse> => {
         let urlParams: URLSearchParams = new URLSearchParams();
         ids.forEach((path: string) => urlParams.append('id', path));
         const parentDocumentNameParam: string = cloudDocumentName ? `&parentName=${cloudDocumentName}` : '';

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -6,7 +6,7 @@ import {NEXTCLOUD_APP} from "../nextcloud.behaviours";
 import models = workspace.v2.models;
 import {WorkspaceEntcoreUtils} from "../utils/workspace-entcore.utils";
 import {INextcloudService, nextcloudService} from "../services";
-import {AxiosError} from "axios";
+import {AxiosError, AxiosResponse} from "axios";
 import {Draggable, SyncDocument} from "../models";
 import {INextcloudUserService, nextcloudUserService} from "../services";
 import {UserNextcloud} from "../models/nextcloud-user.model";
@@ -146,8 +146,14 @@ class ViewModel implements IViewModel {
             if (document && (document._id && document.eType === "file")) {
                 if (angular.element(event.target).scope().folder instanceof SyncDocument) {
                     const syncedDocument: SyncDocument = angular.element(event.target).scope().folder;
-                    // todo DRIV-19
-                    nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, [document._id], syncedDocument.path);
+                    nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, [document._id], syncedDocument.path)
+                        .then((_: AxiosResponse) => WorkspaceEntcoreUtils.updateWorkspaceDocuments(
+                            WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folder'])
+                        )
+                        .catch((err: AxiosError) => {
+                            const message: string = "Error while attempting to fetch documents children ";
+                            console.error(message + err.message);
+                        });
                 }
             }
         }


### PR DESCRIPTION
## Describe your changes

⚠ si possible, merge la PR https://github.com/OPEN-ENT-NG/nextcloud/pull/27 avant de lire celle-ci 

Depuis l'espace doc, on peut glisser et déposer un document depuis le l'espace doc "mes documents personnels" dans l'arborescence nextcloud

En faisant cette action, on supprime le document qu'on a glissé et déposé dans l'espace documentaire "mes documents personnels" (étant donné qu'on fait un déplacement)

## Checklist tests

- [x] drag le document de l'espace doc "mes documents" et le mettre dans le dossier de nextcloud
- [x] vérifier que le document dans l'espace doc a disparu une fois terminé
- [x] vérifier que dans le nextcloud on retrouve bien l'info


## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/DRIV-19

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

