### PR TITLE
fix(rename): renaming file is now working with spaces and plus symbol

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -2,6 +2,7 @@ package fr.openent.nextcloud.controller;
 
 import fr.openent.nextcloud.core.constants.Field;
 import fr.openent.nextcloud.helper.FileHelper;
+import fr.openent.nextcloud.helper.StringHelper;
 import fr.openent.nextcloud.security.OwnerFilter;
 import fr.openent.nextcloud.service.DocumentsService;
 import fr.openent.nextcloud.service.ServiceFactory;
@@ -100,10 +101,11 @@ public class DocumentsController extends ControllerHelper {
             UserUtils.getUserInfos(eb, request, user ->
                     userService.getUserSession(user.getUserId())
                             .compose(userSession -> {
-                                String formattedPath = path.replace(" ", "%20");
-                                String formattedDestPath = destPath.replace(" ", "%20");
-                                return documentsService.moveDocument(userSession, formattedPath, formattedDestPath);
-                            })
+                                        String finalPath = StringHelper.encodeUrlForNc(path);
+                                        String finalDestPath = StringHelper.encodeUrlForNc(destPath);
+                                        return documentsService.moveDocument(userSession, finalPath, finalDestPath);
+                                    }
+                            )
                             .onSuccess(res -> renderJson(request, res))
                             .onFailure(err -> renderError(request, new JsonObject().put(Field.MESSAGE, err.getMessage()))));
         } else {

--- a/src/main/java/fr/openent/nextcloud/helper/StringHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/StringHelper.java
@@ -1,5 +1,7 @@
 package fr.openent.nextcloud.helper;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.Normalizer;
 
 public class StringHelper {
@@ -12,5 +14,32 @@ public class StringHelper {
         return Normalizer
                 .normalize(value, Normalizer.Form.NFD)
                 .replaceAll("[^\\p{ASCII}]", "");
+    }
+
+    /**
+     * Remove first character from the string if the first character matches the firstChar param.
+     * @param firstChar     First character to check.
+     * @param string        The string you want to remove the character from.
+     * @return              The string without first character.
+     */
+    public static String removeFirstChar(String firstChar, String string) {
+        return string.startsWith(firstChar) ? string.substring(1) : string;
+    }
+
+    /**
+     * Encode URL for Nextcloud server
+     * @param url   Default URL
+     * @return      Modified URL
+     */
+    public static String encodeUrlForNc(String url) {
+        url = removeFirstChar("/", url);
+        try {
+            url = URLEncoder.encode(url, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        url = url.replace("%2F", "/")
+                .replace("+", "%20");
+        return url;
     }
 }

--- a/src/main/java/fr/openent/nextcloud/helper/StringHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/StringHelper.java
@@ -39,7 +39,7 @@ public class StringHelper {
         try {
             subUrl = URLEncoder.encode(subUrl, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            String messageToFormat = "[Nextcloud@%s::encodeUrlForNc] Error while encoding URL : %s";
+            String messageToFormat = "[Nextcloud@::encodeUrlForNc] Error while encoding URL : %s";
             log.error(String.format(messageToFormat, e.getMessage()));
             return subUrl;
         }

--- a/src/main/java/fr/openent/nextcloud/helper/StringHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/StringHelper.java
@@ -1,11 +1,14 @@
 package fr.openent.nextcloud.helper;
 
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.Normalizer;
 
 public class StringHelper {
-
+    private static final Logger log = LoggerFactory.getLogger(StringHelper.class);
     private StringHelper() {
         throw new IllegalStateException("Utility StringHelper class");
     }
@@ -32,14 +35,16 @@ public class StringHelper {
      * @return      Modified URL
      */
     public static String encodeUrlForNc(String url) {
-        url = removeFirstChar("/", url);
+        String subUrl = removeFirstChar("/", url);
         try {
-            url = URLEncoder.encode(url, "UTF-8");
+            subUrl = URLEncoder.encode(subUrl, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+            String messageToFormat = "[Nextcloud@%s::encodeUrlForNc] Error while encoding URL : %s";
+            log.error(String.format(messageToFormat, e.getMessage()));
+            return subUrl;
         }
-        url = url.replace("%2F", "/")
+        subUrl = subUrl.replace("%2F", "/")
                 .replace("+", "%20");
-        return url;
+        return subUrl;
     }
 }

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -26,7 +26,6 @@ import org.entcore.common.bus.WorkspaceHelper;
 import org.entcore.common.storage.Storage;
 import org.entcore.common.user.UserInfos;
 
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/resources/public/ts/models/nextcloud.folder.model.ts
+++ b/src/main/resources/public/ts/models/nextcloud.folder.model.ts
@@ -31,7 +31,7 @@ export class SyncDocument {
     isNextcloudParent?: boolean;
 
     build(data: IDocumentResponse): SyncDocument {
-        this.name = decodeURI(data.displayname);
+        this.name = decodeURIComponent(data.displayname);
         this.ownerDisplayName = data.ownerDisplayName;
         this.path = data.path.split(model.me.userId).pop();
         this.contentType = data.contentType;

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
@@ -74,8 +74,7 @@ export class ToolbarSnipletViewModel implements IViewModel {
     renameDocument(): void {
         const oldDocumentToRename: SyncDocument = this.vm.selectedDocuments[0];
         if (oldDocumentToRename) {
-            // we take old document path and we replace the matched file name by the new one
-            const targetDocument: string = decodeURI(this.currentDocument.path).replace(oldDocumentToRename.name, this.currentDocument.name);
+            const targetDocument: string = (this.vm.parentDocument.path == null ? "" : this.vm.parentDocument.path) + "/" + encodeURIComponent(this.currentDocument.name);
             this.vm.nextcloudService.moveDocument(model.me.userId, oldDocumentToRename.path, targetDocument)
                 .then(() => {
                     return this.vm.nextcloudService.listDocument(model.me.userId, this.vm.parentDocument.path ?


### PR DESCRIPTION
## Describe your changes
Before this update, renaming a file wasn't working. Plus symbol and spaces was misinterpreted by Nextcloud server.
To fix that, we modified front by removing pre-encoding and we are now managing encoding in back.
## Checklist tests
Checked on browser.
## Issue ticket number and link
No ticket, it's part of the core.
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

