### PR TITLE
feat(move): #DRIV-38 API now return everything about the file moved or copied

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -161,7 +161,7 @@ public class DocumentsController extends ControllerHelper {
             UserUtils.getUserInfos(eb, request, user ->
                 userService.getUserSession(user.getUserId())
                         .compose(userSession -> documentsService.moveDocumentToWorkspace(userSession, user, listFiles, parentId))
-                        .onSuccess(res -> renderJson(request, res))
+                        .onSuccess(res -> renderJson(request, new JsonObject().put(Field.DATA, res)))
                         .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
         else
             badRequest(request);
@@ -178,7 +178,7 @@ public class DocumentsController extends ControllerHelper {
             UserUtils.getUserInfos(eb, request, user ->
                 userService.getUserSession(user.getUserId())
                         .compose(userSession -> documentsService.copyDocumentToWorkspace(userSession, user, listFiles, parentId))
-                        .onSuccess(res -> renderJson(request, res))
+                        .onSuccess(res -> renderJson(request, new JsonObject().put(Field.DATA, res)))
                         .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
         else
             badRequest(request);

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -75,6 +75,7 @@ public class Field {
     public static final String OK = "OK";
     public static final String OK_LOWER = "ok";
     public static final String KO = "KO";
+    public static final String KO_LOWER = "ko";
 
 
     public static final String ISFOLDER = "isFolder";

--- a/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
@@ -83,9 +83,9 @@ public interface DocumentsService {
      * @param user              User infos
      * @param filesPath         Path of all the files to move
      * @param parentId          Identifier of the previous folder if moving in a folder
-     * @return                  Future Json with the infos about every move
+     * @return                  Future list of JsonObject with infos about every file copied
      */
-    Future<JsonObject> copyDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
+    Future<List<JsonObject>> copyDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
 
     /**
      * Move all the files listed in the filesPath from nextcloud to local.
@@ -93,9 +93,9 @@ public interface DocumentsService {
      * @param user              User infos
      * @param filesPath         Path of all the files to move
      * @param parentId          Identifier of the previous folder if moving in a folder
-     * @return                  Future Json with the infos about every move
+     * @return                  Future list of JsonObject with infos about every file moved
      */
-    Future<JsonObject> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
+    Future<List<JsonObject>> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
 
     /**
      * Move all the files listed in id idList from workspace to Nextcloud

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -27,9 +27,11 @@ import org.entcore.common.storage.Storage;
 import org.entcore.common.user.UserInfos;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DefaultDocumentsService implements DocumentsService {
     private final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
@@ -311,20 +313,27 @@ public class DefaultDocumentsService implements DocumentsService {
      * @param user              User infos
      * @param filesPath         Path of all the files to move
      * @param parentId          Identifier of the previous folder if moving in a folder
-     * @return                  Future Json with the infos about every copy
+     * @return                  Future list of JsonObject with infos about every file copied
      */
-    public Future<JsonObject> copyDocumentToWorkspace(UserNextcloud.TokenProvider userSession,
+    public Future<List<JsonObject>> copyDocumentToWorkspace(UserNextcloud.TokenProvider userSession,
                                                       UserInfos user,
                                                       List<String> filesPath,
                                                       String parentId) {
-        Promise<JsonObject> promise = Promise.promise();
+        Promise<List<JsonObject>> promise = Promise.promise();
         Future<JsonObject> current = Future.succeededFuture();
-
-        JsonObject result = new JsonObject();
+        List<Future<JsonObject>> listResult = new ArrayList<>();
         for (String file : filesPath) {
-            current = current.compose(v -> copyToWorkspace(userSession, user, file.startsWith("/") ? file.substring(1) : file, result, parentId));
+            current = current.compose(v -> {
+                Future<JsonObject> future = copyToWorkspace(userSession, user, file.startsWith("/") ? file.substring(1) : file, parentId);
+                Promise<JsonObject> succeedPromise = Promise.promise();
+                future
+                        .onSuccess( r -> listResult.add(future))
+                        .onFailure( r -> listResult.add(Future.succeededFuture(new JsonObject().put(file, future.cause().getMessage()))))
+                        .onComplete(r -> succeedPromise.complete());
+                return succeedPromise.future();
+            });
         }
-        current.onSuccess(res -> promise.complete(result))
+        current.onSuccess(res -> promise.complete(listResult.stream().map(Future::result).collect(Collectors.toList())))
                 .onFailure(err -> {
                     String messageToFormat = "[Nextcloud@%s::copyDocumentToWorkspace] An error has occurred during copy : %s";
                     PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);
@@ -339,20 +348,29 @@ public class DefaultDocumentsService implements DocumentsService {
      * @param user              User infos
      * @param filesPath         Path of all the files to move
      * @param parentId          Identifier of the previous folder if moving in a folder
-     * @return                  Future Json with infos about every move
+     * @return                  Future list of JsonObject with infos about every file moved
      */
     @Override
-    public Future<JsonObject> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession,
-                                                      UserInfos user,
-                                                      List<String> filesPath,
-                                                      String parentId) {
-        Promise<JsonObject> promise = Promise.promise();
+    public Future<List<JsonObject>> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession,
+                                                            UserInfos user,
+                                                            List<String> filesPath,
+                                                            String parentId) {
+        Promise<List<JsonObject>> promise = Promise.promise();
         Future<JsonObject> current = Future.succeededFuture();
-        JsonObject result = new JsonObject();
+        List<Future<JsonObject>> result = new ArrayList<>();
         for (String file : filesPath) {
-            current = current.compose(v -> moveToWorkspace(userSession, user, file.startsWith("/") ? file.substring(1) : file, result, parentId));
+            current = current.compose(v -> {
+                Future<JsonObject> future = moveToWorkspace(userSession, user, file.startsWith("/") ? file.substring(1) : file, parentId);
+                Promise<JsonObject> succeedPromise = Promise.promise();
+                future
+                        .onSuccess( r -> result.add(future))
+                        .onFailure( r -> result.add(Future.succeededFuture(new JsonObject().put(file, future.cause().getMessage()))))
+                        .onComplete(r -> succeedPromise.complete());
+                return succeedPromise.future();
+            });
+
         }
-        current.onSuccess(res -> promise.complete(result))
+        current.onSuccess(v -> promise.complete(result.stream().map(Future::result).collect(Collectors.toList())))
                 .onFailure(err -> {
                     String messageToFormat = "[Nextcloud@%s::moveDocumentToWorkspace] An error has occurred while moving documents : %s";
                     PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);
@@ -364,14 +382,12 @@ public class DefaultDocumentsService implements DocumentsService {
      * @param userSession       User session
      * @param user              User infos
      * @param file              Path of the file you want to move
-     * @param result            Json where status of move is stored
      * @param parentId          Identifier of the previous folder if moving in a folder
      * @return                  Future Json with the infos about the copy
      */
     private Future<JsonObject> copyToWorkspace(UserNextcloud.TokenProvider userSession,
                                                UserInfos user,
                                                String file,
-                                               JsonObject result,
                                                String parentId) {
         Promise<JsonObject> promiseResult = Promise.promise();
         //The listFiles function here is called to gather data on one specific file.
@@ -386,24 +402,21 @@ public class DefaultDocumentsService implements DocumentsService {
                             return;
                         }
                         if (Boolean.FALSE.equals(fileInfo.getJsonObject(0).getBoolean(Field.ISFOLDER))) {
-                            storeFileWorkspace(userSession, user, file, parentId).onComplete(status -> {
-                                if (status.succeeded()) {
-                                    result.put(file, status.result());
+                            storeFileWorkspace(userSession, user, file, parentId).onComplete(fileInfos -> {
+                                if (fileInfos.succeeded()) {
+                                    promiseResult.complete(fileInfos.result());
                                 }
                                 else {
-                                    result.put(file, status.cause().getMessage());
+                                    promiseResult.fail(fileInfos.cause().getMessage());
                                 }
-                                promiseResult.complete();
                             });
                         } else {
                             //TODO Gérer le cas d'import d'un dossier
                             log.error("[Nextcloud@%s::copyToWorkspace] import.directory.not.handled");
-                            result.put(file, "import.directory.not.handled");
-                            promiseResult.complete();
+                            promiseResult.fail("import.directory.not.handled");
                         }
                     } else {
-                        result.put(file, "nextcloud.server.file.no.exist");
-                        promiseResult.complete();
+                        promiseResult.fail("nextcloud.server.file.no.exist");
                     }
 
                 })
@@ -419,14 +432,12 @@ public class DefaultDocumentsService implements DocumentsService {
      * @param userSession       User session
      * @param user              User infos
      * @param file              Path of the file you want to move
-     * @param result            Json where status of move is stored
      * @param parentId          Identifier of the previous folder if moving in a folder
      * @return                  Future Json with the infos about the move
      */
     private Future<JsonObject> moveToWorkspace(UserNextcloud.TokenProvider userSession,
                                                UserInfos user,
                                                String file,
-                                               JsonObject result,
                                                String parentId) {
         Promise<JsonObject> promiseResult = Promise.promise();
         //The listFiles function here is called to gather data on one specific file.
@@ -434,7 +445,6 @@ public class DefaultDocumentsService implements DocumentsService {
                 .onSuccess(fileInfo -> {
                     if (!fileInfo.isEmpty()) {
                         JsonObject resJson = fileInfo.getJsonObject(0);
-
                         if (!resJson.containsKey(Field.DISPLAYNAME) || resJson.getString(Field.DISPLAYNAME).equals("")
                                 || !resJson.containsKey(Field.ISFOLDER)) {
                             String messageToFormat = "[Nextcloud@%s::moveToWorkspace] An error has occurred while retrieving data from file : %s";
@@ -443,24 +453,20 @@ public class DefaultDocumentsService implements DocumentsService {
                         }
                         if (Boolean.FALSE.equals(fileInfo.getJsonObject(0).getBoolean(Field.ISFOLDER))) {
                             retrieveAndDeleteFile(userSession, user, file, parentId)
-                                    .onComplete(status -> {
-                                if (status.succeeded()) {
-                                    //
-                                    result.put(file, status.result());
+                                    .onComplete(fileInfos -> {
+                                if (fileInfos.succeeded()) {
+                                    promiseResult.complete(fileInfos.result());
                                 } else {
-                                    result.put(file, status.cause().getMessage());
+                                    promiseResult.fail(fileInfos.cause().getMessage());
                                 }
-                                promiseResult.complete();
                             });
                         } else {
                             //TODO Gérer le cas d'import d'un dossier
                             log.error("[Nextcloud@%s::moveToWorkspace] import.directory.not.handled");
-                            result.put(file, "import.directory.not.handled");
-                            promiseResult.complete();
+                            promiseResult.fail("import.directory.not.handled");
                         }
                     } else {
-                        result.put(file, "nextcloud.server.file.no.exist");
-                        promiseResult.complete();
+                        promiseResult.fail("nextcloud.server.file.no.exist");
                     }
                 })
                 .onFailure(err -> {
@@ -510,6 +516,7 @@ public class DefaultDocumentsService implements DocumentsService {
         Promise<JsonObject> promise = Promise.promise();
         String[] splitPath = filePath.split("/");
         String fileName = splitPath[splitPath.length - 1];
+        JsonObject[] fileInfos = new JsonObject[1];
         getFile(userSession, filePath)
                 .compose(buffer ->
                         FileHelper.writeBuffer(storage, buffer.bodyAsBuffer(), buffer.headers().get(Field.CONTENT_TYPE_HEADER), fileName)
@@ -518,8 +525,11 @@ public class DefaultDocumentsService implements DocumentsService {
                     writeInfo.put(Field.PARENTID, parentId);
                     return FileHelper.addFileReference(writeInfo, user, fileName.replace("%20", " "), workspaceHelper);
                 })
-                .compose(resDoc -> moveUnderParent(workspaceHelper, user, parentId, resDoc))
-                .onSuccess(promise::complete)
+                .compose(resDoc -> {
+                    fileInfos[0] = resDoc;
+                    return moveUnderParent(workspaceHelper, user, parentId, resDoc);
+                })
+                .onSuccess(res -> promise.complete(fileInfos[0]))
                 .onFailure(err -> {
                     String messageToFormat = "[Nextcloud@%s::storeFileWorkspace] Error while storing file : %s";
                     PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);


### PR DESCRIPTION
## Describe your changes
Following PR #27. Before this update, the result of the API call was just the status of the move or copy. Now API call return every information about the file in case of succes, and the error message if it fails.
API Documentation : https://entconf.gdapublic.fr/display/DRIV/Nextcloud+Documents+API
## Checklist tests
Both of following routes tested with Postman.
[ PUT ] /files/user/:userid/copy/workspace
[ PUT ] /files/user/:userid/move/workspace
## Issue ticket number and link
[ DRIV-38 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-38
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

