### PR TITLE
feat(nextcloud): #DRIV-38 Move multiple files from Nextcloud to workspace is now working

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -8,6 +8,7 @@ import {ToolbarSnipletViewModel} from "./workspace-nextcloud-toolbar.sniplet";
 import {AxiosError, AxiosResponse} from "axios";
 import {UploadFileSnipletViewModel} from "./workspace-nextcloud-upload-file.sniplet";
 import models = workspace.v2.models;
+import {Object} from "core-js";
 
 declare let window: any;
 
@@ -166,7 +167,11 @@ class ViewModel implements IViewModel {
     }
 
     async moveDocumentToWorkspace(folder: models.Element, document: SyncDocument): Promise<AxiosResponse> {
-        return nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, [document.path], folder._id);
+        let fileToMove: Array<SyncDocument> = Object.assign([], this.selectedDocuments);
+        if (fileToMove.indexOf(document) == -1) {
+            fileToMove.push(document);
+        }
+        return nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, fileToMove.map(file => file.path), folder._id);
     }
 
     onSelectContent(content: SyncDocument): void {

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -143,10 +143,12 @@ class ViewModel implements IViewModel {
         let folderContent: any = angular.element(element).scope();
         if (folderContent && folderContent.folder) {
             if (folderContent.folder instanceof models.Element) {
-                let fileToMove : Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
-                let finalUpload : Array<String> = Array.from(fileToMove).filter(file => !file.isFolder).map(file => file.path);
-                if (finalUpload.length > 0) {
-                    nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, finalUpload, folderContent.folder.id)
+                let fileToMove: Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
+                let finalUpload: Array<string> = Array.from(fileToMove)
+                    .filter((file: SyncDocument) => !file.isFolder)
+                    .map((file: SyncDocument) => file.path);
+                if (finalUpload.length) {
+                    this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, finalUpload, folderContent.folder.id)
                         .then(async (_: AxiosResponse) => {
                             return nextcloudService.listDocument(model.me.userId, selectedFolderFromNextcloudTree.path ?
                                 selectedFolderFromNextcloudTree.path : null);

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -171,7 +171,7 @@ class ViewModel implements IViewModel {
         if (fileToMove.indexOf(document) == -1) {
             fileToMove.push(document);
         }
-        return nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, fileToMove.map(file => file.path), folder._id);
+        return nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, fileToMove.filter(file => !file.isFolder).map(file => file.path), folder._id);
     }
 
     onSelectContent(content: SyncDocument): void {


### PR DESCRIPTION
## Describe your changes
It is now possible to drop multiple files into workspace from Nextcloud. Before this update, the API was able to handle multiple move but the front was not giving the rights parameters.
## Checklist tests
Checked on browser.
- [x] Move one file from Nextcloud to Workspace
- [x] Move multiple selected files from Nextcloud to workspace
- [x] Move multiple files by dragging one unselected file while others were selected.
- [ ] Move one folder from from Nextcloud to workspace
- [ ] Move multiple folder from Nextcloud to workspace
## Issue ticket number and link
[ DRIV-38 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-38
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

