### PR TITLE
feat(nextcloud): #DRIV-19 Move multiple files from workspace to Nextcloud is now working

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -1,4 +1,4 @@
-import {FolderTreeProps, angular, template, Behaviours, workspace, model, idiom as lang} from "entcore";
+import {FolderTreeProps, angular, template, Behaviours, workspace, model, idiom as lang, Document} from "entcore";
 import {Tree} from "entcore/types/src/ts/workspace/model";
 import {safeApply} from "../utils/safe-apply.utils";
 import {RootsConst} from "../core/constants/roots.const";
@@ -146,7 +146,10 @@ class ViewModel implements IViewModel {
             if (document && (document._id && document.eType === "file")) {
                 if (angular.element(event.target).scope().folder instanceof SyncDocument) {
                     const syncedDocument: SyncDocument = angular.element(event.target).scope().folder;
-                    nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, [document._id], syncedDocument.path)
+                    let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['documentList']['_documents'];
+                    let documentToUpdate: Set<string> = new Set(selectedDocuments.filter((file: Document) => file.selected).map((file: Document) => file._id));
+                    documentToUpdate.add(document._id);
+                    nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, Array.from(documentToUpdate), syncedDocument.path)
                         .then((_: AxiosResponse) => WorkspaceEntcoreUtils.updateWorkspaceDocuments(
                             WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folder'])
                         )


### PR DESCRIPTION
## Describe your changes
It is now possible to drop multiple files into Nextcloud from workspace. Before this update, the API was able to handle multiple moves but the front was not giving the rights parameters.
## Checklist tests
- [x] Move one file from workspace to Nextcloud
- [x] Move multiple selected files from workspace to Nextcloud
- [x] Move multiple files by dragging one unselected file while others were selected.
- [ ] Move one folder from from workspace to Nextcloud
- [ ] Move multiple folder from workspace to Nextcloud
## Issue ticket number and link
[ DRIV-19 ]
https://entsupport.gdapublic.fr/browse/DRIV-19
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

