### PR TITLE
fix(move): #DRIV-38 Move is now working under a specific workspace folder

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -148,7 +148,7 @@ class ViewModel implements IViewModel {
                     .filter((file: SyncDocument) => !file.isFolder)
                     .map((file: SyncDocument) => file.path);
                 if (finalUpload.length) {
-                    this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, finalUpload, folderContent.folder.id)
+                    this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, finalUpload, folderContent.folder._id)
                         .then(async (_: AxiosResponse) => {
                             return nextcloudService.listDocument(model.me.userId, selectedFolderFromNextcloudTree.path ?
                                 selectedFolderFromNextcloudTree.path : null);


### PR DESCRIPTION
## Describe your changes
Following #38. We found a bug: moving a file nextcloud file under a specific workspace folder was not working. The file was moved under the root folder. The problem was that the name of the id attribute in the front code was wrong.
## Checklist tests
Checked on browser.
- [x] Move one file from Nextcloud to Workspace
- [x] Move multiple selected files from Nextcloud to workspace
- [x] Move multiple files by dragging one unselected file while others were selected.
- [ ] Move one folder from from Nextcloud to workspace
- [ ] Move multiple folder from Nextcloud to workspace

## Issue ticket number and link
[ DRIV-38 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-38
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

