### PR TITLE
feat(move): #DRIV-26 move is available for folders

### DIFF
--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -2,7 +2,6 @@ package fr.openent.nextcloud.core.constants;
 
 public class Field {
 
-    public static final String ADDFOLDER = "addFolder";
     public static final String DATA = "data";
     public static final String ID = "id";
     public static final String USERID = "userid";
@@ -16,7 +15,6 @@ public class Field {
     public static final String DISPLAYNAMECAMEL = "displayName";
     public static final String EMAIL = "email";
     public static final String PHONE = "phone";
-    public static final String DELETE = "delete";
     public static final String PARENTNAME = "parentName";
     public static final String ACTION = "action";
     public static final String OWNER = "owner";

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -12,6 +12,7 @@ public class Field {
     public static final String USERNAME = "username";
     public static final String NAME = "name";
     public static final String DISPLAYNAME = "displayname";
+    public static final String YES = "yes";
     public static final String DISPLAYNAMECAMEL = "displayName";
     public static final String EMAIL = "email";
     public static final String PHONE = "phone";

--- a/src/main/java/fr/openent/nextcloud/core/enums/EventBusActions.java
+++ b/src/main/java/fr/openent/nextcloud/core/enums/EventBusActions.java
@@ -1,0 +1,16 @@
+package fr.openent.nextcloud.core.enums;
+
+public enum EventBusActions {
+    ADDFOLDER("addFolder"),
+    DELETE("delete");
+
+    private final String action;
+
+    EventBusActions(String action) {
+        this.action = action;
+    }
+
+    public String action() {
+        return this.action;
+    }
+}

--- a/src/main/java/fr/openent/nextcloud/core/enums/WorkspaceEventBusActions.java
+++ b/src/main/java/fr/openent/nextcloud/core/enums/WorkspaceEventBusActions.java
@@ -1,12 +1,12 @@
 package fr.openent.nextcloud.core.enums;
 
-public enum EventBusActions {
+public enum WorkspaceEventBusActions {
     ADDFOLDER("addFolder"),
     DELETE("delete");
 
     private final String action;
 
-    EventBusActions(String action) {
+    WorkspaceEventBusActions(String action) {
         this.action = action;
     }
 

--- a/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
@@ -1,6 +1,7 @@
 package fr.openent.nextcloud.helper;
 
 import fr.openent.nextcloud.core.constants.Field;
+import fr.openent.nextcloud.core.enums.EventBusActions;
 import fr.openent.nextcloud.service.impl.DefaultDocumentsService;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -17,24 +18,26 @@ public class EventBusHelper {
 
     /**
      * Create a folder ine the workspace
-     * @param folder    JsonObject with folder's infos
-     * @param userId    User's identifier
-     * @param userName  User's username
-     * @return          Future with the status of the folder creation
+     * @param eb                The current eventBus
+     * @param folderName        Name of the new folder
+     * @param folderParentId    Identifier of parent folder in the workspace
+     * @param userId            User's identifier
+     * @param userName          User's username
+     * @return                  Future with the status of the folder creation
      */
-    public static Future<JsonObject> createFolder(EventBus eb, JsonObject folder, String userId, String userName) {
+    public static Future<JsonObject> createFolder(EventBus eb, String folderName, String folderParentId, String userId, String userName) {
         JsonObject action = new JsonObject()
-                .put(Field.ACTION, Field.ADDFOLDER)
-                .put(Field.NAME, folder.getString(Field.NAME))
+                .put(Field.ACTION, EventBusActions.ADDFOLDER)
+                .put(Field.NAME, folderName)
                 .put(Field.OWNER, userId)
                 .put(Field.OWNERNAME, userName)
-                .put(Field.PARENTFOLDERID, folder.getString(Field.PARENT_ID));
+                .put(Field.PARENTFOLDERID, folderParentId);
         return requestJsonObject(eb, action);
     }
 
     public static Future<JsonArray> deleteDocument(EventBus eb, String id, String userId) {
         JsonObject action =  new JsonObject()
-                .put(Field.ACTION, Field.DELETE)
+                .put(Field.ACTION, EventBusActions.DELETE)
                 .put(Field.ID, id)
                 .put(Field.USERID_CAPS, userId);
         return requestJsonArray(eb, action);

--- a/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
@@ -1,7 +1,7 @@
 package fr.openent.nextcloud.helper;
 
 import fr.openent.nextcloud.core.constants.Field;
-import fr.openent.nextcloud.core.enums.EventBusActions;
+import fr.openent.nextcloud.core.enums.WorkspaceEventBusActions;
 import fr.openent.nextcloud.service.impl.DefaultDocumentsService;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -19,25 +19,16 @@ public class EventBusHelper {
     /**
      * Create a folder ine the workspace
      * @param eb                The current eventBus
-     * @param folderName        Name of the new folder
-     * @param folderParentId    Identifier of parent folder in the workspace
-     * @param userId            User's identifier
-     * @param userName          User's username
+     * @param action            The action parameters to send to the event bus
      * @return                  Future with the status of the folder creation
      */
-    public static Future<JsonObject> createFolder(EventBus eb, String folderName, String folderParentId, String userId, String userName) {
-        JsonObject action = new JsonObject()
-                .put(Field.ACTION, EventBusActions.ADDFOLDER.action())
-                .put(Field.NAME, folderName)
-                .put(Field.OWNER, userId)
-                .put(Field.OWNERNAME, userName)
-                .put(Field.PARENTFOLDERID, folderParentId);
+    public static Future<JsonObject> createFolder(EventBus eb, JsonObject action) {
         return requestJsonObject(eb, action);
     }
 
     public static Future<JsonArray> deleteDocument(EventBus eb, String id, String userId) {
         JsonObject action =  new JsonObject()
-                .put(Field.ACTION, EventBusActions.DELETE.action())
+                .put(Field.ACTION, WorkspaceEventBusActions.DELETE.action())
                 .put(Field.ID, id)
                 .put(Field.USERID_CAPS, userId);
         return requestJsonArray(eb, action);

--- a/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
@@ -27,7 +27,7 @@ public class EventBusHelper {
      */
     public static Future<JsonObject> createFolder(EventBus eb, String folderName, String folderParentId, String userId, String userName) {
         JsonObject action = new JsonObject()
-                .put(Field.ACTION, EventBusActions.ADDFOLDER)
+                .put(Field.ACTION, EventBusActions.ADDFOLDER.action())
                 .put(Field.NAME, folderName)
                 .put(Field.OWNER, userId)
                 .put(Field.OWNERNAME, userName)
@@ -37,7 +37,7 @@ public class EventBusHelper {
 
     public static Future<JsonArray> deleteDocument(EventBus eb, String id, String userId) {
         JsonObject action =  new JsonObject()
-                .put(Field.ACTION, EventBusActions.DELETE)
+                .put(Field.ACTION, EventBusActions.DELETE.action())
                 .put(Field.ID, id)
                 .put(Field.USERID_CAPS, userId);
         return requestJsonArray(eb, action);

--- a/src/main/java/fr/openent/nextcloud/helper/MessageResponseHandler.java
+++ b/src/main/java/fr/openent/nextcloud/helper/MessageResponseHandler.java
@@ -12,7 +12,10 @@ public class MessageResponseHandler {
     public static Handler<AsyncResult<Message<JsonObject>>> messageJsonObjectHandler(Handler<Either<String, JsonObject>> handler) {
         return event -> {
             if (event.succeeded() && Field.OK_LOWER.equals(event.result().body().getString(Field.STATUS))) {
-                handler.handle(new Either.Right<>(event.result().body()));
+                if (!event.result().body().containsKey(Field.RESULT))
+                    handler.handle(new Either.Right<>(event.result().body()));
+                else
+                    handler.handle(new Either.Right<>(event.result().body().getJsonObject(Field.RESULT)));
             } else {
                 if (event.failed()) {
                     handler.handle(new Either.Left<>(event.cause().getMessage()));

--- a/src/main/java/fr/openent/nextcloud/helper/MessageResponseHandler.java
+++ b/src/main/java/fr/openent/nextcloud/helper/MessageResponseHandler.java
@@ -12,7 +12,7 @@ public class MessageResponseHandler {
     public static Handler<AsyncResult<Message<JsonObject>>> messageJsonObjectHandler(Handler<Either<String, JsonObject>> handler) {
         return event -> {
             if (event.succeeded() && Field.OK_LOWER.equals(event.result().body().getString(Field.STATUS))) {
-                handler.handle(new Either.Right<>(event.result().body().getJsonObject(Field.RESULT)));
+                handler.handle(new Either.Right<>(event.result().body()));
             } else {
                 if (event.failed()) {
                     handler.handle(new Either.Left<>(event.cause().getMessage()));

--- a/src/main/java/fr/openent/nextcloud/model/NextcloudFolder.java
+++ b/src/main/java/fr/openent/nextcloud/model/NextcloudFolder.java
@@ -1,0 +1,66 @@
+package fr.openent.nextcloud.model;
+
+import fr.openent.nextcloud.core.constants.Field;
+import fr.openent.nextcloud.service.impl.DefaultDocumentsService;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class is the representation of a folder in the nextcloud server.
+ */
+public class NextcloudFolder {
+    private String name;
+    private List<JsonObject> folderItemsInfos = new ArrayList<>();
+    private String workspaceId;
+    private String path;
+    public NextcloudFolder(JsonArray folderInfos) {
+        try {
+            this.folderItemsInfos = folderInfos.stream().map(fileInfo -> new JsonObject(
+                    fileInfo.toString())).collect(Collectors.toList());
+            this.name = this.folderItemsInfos.get(0).getString(Field.DISPLAYNAME);
+            //removing first one because it is the folder itself.
+            this.folderItemsInfos.remove(0);
+        } catch (Exception e) {
+            log.error("[Nextcloud@::NextcloudFolder] Error while instantiating NextcloudFolder class");
+        }
+    }
+    private final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
+
+    public List<JsonObject> getFolderItemsInfos() {
+        return folderItemsInfos;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getFolderItemsNames() {
+        return this.folderItemsInfos.stream().map(fileInfos -> new JsonObject(fileInfos.toString()).getString(Field.DISPLAYNAME)).collect(Collectors.toList());
+    }
+
+    public List<String> getFolderItemPath() {
+        return this.getFolderItemsNames().stream().map(r -> (path != null ? path + "/" : "") + r).collect(Collectors.toList());
+    }
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = workspaceId;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/src/main/java/fr/openent/nextcloud/model/NextcloudFolder.java
+++ b/src/main/java/fr/openent/nextcloud/model/NextcloudFolder.java
@@ -19,14 +19,16 @@ public class NextcloudFolder {
     private List<JsonObject> folderItemsInfos = new ArrayList<>();
     private String workspaceId;
     private String path;
+    private Boolean isSet = true;
     public NextcloudFolder(JsonArray folderInfos) {
         try {
             this.folderItemsInfos = folderInfos.stream().map(fileInfo -> new JsonObject(
                     fileInfo.toString())).collect(Collectors.toList());
-            this.name = this.folderItemsInfos.get(0).getString(Field.DISPLAYNAME);
+            this.name = this.folderItemsInfos.get(0).getString(Field.DISPLAYNAME).replace("%20", " ");
             //removing first one because it is the folder itself.
             this.folderItemsInfos.remove(0);
         } catch (Exception e) {
+            this.isSet = false;
             log.error("[Nextcloud@::NextcloudFolder] Error while instantiating NextcloudFolder class");
         }
     }
@@ -62,5 +64,9 @@ public class NextcloudFolder {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public Boolean isSet() {
+        return isSet;
     }
 }

--- a/src/main/java/fr/openent/nextcloud/model/NextcloudFolder.java
+++ b/src/main/java/fr/openent/nextcloud/model/NextcloudFolder.java
@@ -20,6 +20,8 @@ public class NextcloudFolder {
     private String workspaceId;
     private String path;
     private Boolean isSet = true;
+    private final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
+
     public NextcloudFolder(JsonArray folderInfos) {
         try {
             this.folderItemsInfos = folderInfos.stream().map(fileInfo -> new JsonObject(
@@ -29,10 +31,9 @@ public class NextcloudFolder {
             this.folderItemsInfos.remove(0);
         } catch (Exception e) {
             this.isSet = false;
-            log.error("[Nextcloud@::NextcloudFolder] Error while instantiating NextcloudFolder class");
+            log.error(String.format("[Nextcloud@::NextcloudFolder] Error while instantiating NextcloudFolder class : %s", e.getMessage()));
         }
     }
-    private final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
 
     public List<JsonObject> getFolderItemsInfos() {
         return folderItemsInfos;

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -775,6 +775,14 @@ public class DefaultDocumentsService implements DocumentsService {
         return promise.future();
     }
 
+    /**
+     * Recursively call nextcloud API to know if a file with the same name exists on nextcloud server, if the answer is yes,
+     * call again this method with a number of copy after the initial name (e.g. name (1).txt).
+     * @param userSession       Session of the user.
+     * @param path              The path of the file.
+     * @param duplicateNumber   Number of previous call to this function.
+     * @return                  A file name which is not already used on the nextcloud.
+     */
     private Future<String> getUniqueFileName(UserNextcloud.TokenProvider userSession, String path, int duplicateNumber) {
         Promise<String> promise = Promise.promise();
         String extension = "";

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -1,6 +1,7 @@
 package fr.openent.nextcloud.service.impl;
 import fr.openent.nextcloud.config.NextcloudConfig;
 import fr.openent.nextcloud.core.constants.Field;
+import fr.openent.nextcloud.core.enums.WorkspaceEventBusActions;
 import fr.openent.nextcloud.core.enums.NextcloudHttpMethod;
 import fr.openent.nextcloud.core.enums.XmlnsAttr;
 import fr.openent.nextcloud.helper.*;
@@ -337,7 +338,13 @@ public class DefaultDocumentsService implements DocumentsService {
             return promise.future();
         }
         ncFolder.setPath(file);
-        EventBusHelper.createFolder(eventBus, ncFolder.getName(), parentId, user.getUserId(), user.getUsername())
+        JsonObject action = new JsonObject()
+                .put(Field.ACTION, WorkspaceEventBusActions.ADDFOLDER.action())
+                .put(Field.NAME, ncFolder.getName())
+                .put(Field.OWNER, user.getUserId())
+                .put(Field.OWNERNAME, user.getUsername())
+                .put(Field.PARENTFOLDERID, parentId);
+        EventBusHelper.createFolder(eventBus, action)
                 .compose(folderInfos -> {
                     ncFolder.setWorkspaceId(folderInfos.getString(Field.UNDERSCORE_ID));
                     return copyDocumentToWorkspace(userSession, user, ncFolder.getFolderItemPath(), ncFolder.getWorkspaceId());

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -374,14 +374,14 @@ public class DefaultDocumentsService implements DocumentsService {
      */
     Future<JsonObject> folderMove(JsonArray fileInfo, String file, String parentId, UserInfos user, UserNextcloud.TokenProvider userSession) {
         Promise<JsonObject> promise = Promise.promise();
-        Map<String, JsonObject> result = new HashMap<>();
+        JsonObject result = new JsonObject();
 
         folderCopy(fileInfo, file, parentId, user, userSession)
                 .compose(folderCopyInfos -> {
                     result.put(Field.RESULT, folderCopyInfos);
                     return deleteDocument(userSession, file);
                 })
-                .onSuccess(deleteStatus -> promise.complete(result.get(Field.RESULT)))
+                .onSuccess(deleteStatus -> promise.complete(result.getJsonObject(Field.RESULT)))
                 .onFailure(err -> {
                     String messageToFormat = "[Nextcloud@%s::folderMove] Error while handling folder move : %s";
                     PromiseHelper.reject(log, messageToFormat, this.getClass().getSimpleName(), err, promise);

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -145,7 +145,6 @@ class ViewModel implements IViewModel {
             if (folderContent.folder instanceof models.Element) {
                 let fileToMove: Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
                 let finalUpload: Array<string> = Array.from(fileToMove)
-                    .filter((file: SyncDocument) => !file.isFolder)
                     .map((file: SyncDocument) => file.path);
                 if (finalUpload.length) {
                     this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, finalUpload, folderContent.folder._id)

--- a/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
+++ b/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
@@ -1,6 +1,6 @@
 import {angular, Folder, workspace} from "entcore";
 import models = workspace.v2.models;
-
+import WorkspaceEvent = workspace.v2.WorkspaceEvent;
 export class WorkspaceEntcoreUtils {
 
     static $ENTCORE_WORKSPACE: string = `div[data-ng-include="'folder-content'"]`;
@@ -53,14 +53,13 @@ export class WorkspaceEntcoreUtils {
     static updateWorkspaceDocuments(folder: any | models.Element): void {
         if (folder && folder instanceof models.Element) {
             if ("tree" in folder) {
-                WorkspaceEntcoreUtils.workspaceScope()['onTreeInit'](() =>
-                    WorkspaceEntcoreUtils.workspaceScope()['setCurrentTree'](folder['tree']['filter'])
-                )
-            } else if (folder._id && folder.eType === "folder") {
-                WorkspaceEntcoreUtils.workspaceScope()['onTreeInit'](() =>
-                    WorkspaceEntcoreUtils.workspaceScope()['openFolderById'](folder._id)
-                )
+                folder.eType = 'folder';
             }
+            const event : WorkspaceEvent = {
+                action: "tree-change",
+                elements: [folder]
+            }
+            workspace.v2.service.onChange.next(event);
         }
     }
 }

--- a/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
+++ b/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
@@ -52,6 +52,7 @@ export class WorkspaceEntcoreUtils {
      */
     static updateWorkspaceDocuments(folder: any | models.Element): void {
         if (folder && folder instanceof models.Element) {
+            //The root folder does not contain the eType attribute, so we add it to make the refresh happen on this folder too.
             if ("tree" in folder) {
                 folder.eType = 'folder';
             }

--- a/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
+++ b/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
@@ -52,7 +52,10 @@ export class WorkspaceEntcoreUtils {
      */
     static updateWorkspaceDocuments(folder: any | models.Element): void {
         if (folder && folder instanceof models.Element) {
-            //The root folder does not contain the eType attribute, so we add it to make the refresh happen on this folder too.
+            //The root folder is treated differently because it contains all the tree of files and folders, and we can't apply
+            // the same treatment as if it was a classic folder.
+            //As it is not a folder, it does not contain the eType attribute, so we have to simulate it by adding the eType attribute,
+            // and make the refresh happen on this root folder.
             if ("tree" in folder) {
                 folder.eType = 'folder';
             }


### PR DESCRIPTION
## Describe your changes
Following of #12. It is now possible to move and copy folder and not anymore just files. We also add the possibility to move / copy multiple files with the same name from workspace to nextcloud without overwriting it after the first copy / move.

When we use this new feature, it can bring some inconveniences to the user. As it enables you to move as much file as you want from nextcloud to workspace, this action can end up creating a lot of files in your workspace.

In this context of move / copy, we mainly use  : 

`moveDocumentToWorkspace / copyDocumentToWorkspace` : these 2 functions take a list of path (from nextloud) to copy or move the corresponding files / folders in the workspace. 
From here we will handle the things differently depending on the link target type (folder or file). 
In the case of simple file, we will basically retrieve the file from the nextcloud and create a new document in the workspace. 
This one will check the quota of space available for the user. If it's a move, we will then delete it from nextcloud server. 

In the case of a folder, there are multiples  actions that will be executed. 

- The first one will be the creation of the folder in the workspace (because for each file and folder, you need to create the same on the workspace using ENTCORE methods). Since we are using the workspace and the workspaceHelper does not allow us to create folders, we need to use the eventBus, using it on the workspace URI. 
To make the code more understandable, we created a function `folderCopy` whose purpose is to create a  `NextcloudFolder` object (this class helps representing a nextcloud folder into the java code in order to manipulate it more easily) and then call the event bus to create the corresponding folder into the workspace.
After this call on the eventBus, we will end up in the ENT-CORE function `workspaceEventBusHandler` which will manage the folder creation. We have to keep in mind that one user can create AS MUCH FOLDERS AS HE WANTS. There is no check on this number of folders created.

- The second one happen once the folder is created in the workspace. From here, the `folderCopy` function will list all the subfiles and subfolers  of the current nextcloud folder we want to move or copy, then it creates a list from these and then call again `moveDocumentToWork / copyDocumentToWorkspace` with this new list. Here happen the recursivity and checks are necessary because it can leads to the creation of many files.
 
This creation of folders leads to a technical problem : 
At this moment, when you load the workspace page of one user, it tries to display every files and folders and this action may lead to a crash of your browser. As a matter of fact, display a huge amount of files and folders will, depending on your PC ressources, lead to a huge amount of calculations on your PC and your browser will kill the process. Once a user workspace is overloaded by files, it is not possible for the user to fix it by himself and his browser will continue to crash each time he will try to load the page. The user user needs to contact us and we will help him clean his workspace.
This situation can happen, but it's unlikely to happen in common uses. 

OTHER FIX: We also fixed an other bug. Before this update, during a move / copy, the file tree of workspace was updated only  if the moved object was a file. We fixed that by adding a refresh of the tree at every move / copy.
## Checklist tests

- [x] Move / Copy folder from NC to workspace
- [x] Move / Copy one folder and a file from NC to workspace
- [x] Move / Copy folder with subfolders from NC to workspace
- [x] Move / Copy root directory from NC
- [x] Move / Copy folder with spaces in its name
- [x] Move / Copy folder with corresponding subfolders and files
- [x] Copy twice the same folder

Heavy copy or move is for the moment allowed. 

## Issue ticket number and link
[ DRIV-26 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-26?filter=allopenissues
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

