### PR TITLE
feat(virtual-folder): #DRIV-25 add virtual folder implementation

### DIFF
--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "nextcloud.title": "Nextcloud",
+  "nextcloud.virtual.media.title": "Nextcloud",
   "nextcloud.documents": "Synchronized documents",
   "create.nextcloud.documents": "Create a synchronized folder",
   "nextcloud.quota": "Synchronized used space",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -1,5 +1,6 @@
 {
   "nextcloud.title": "Nextcloud",
+  "nextcloud.virtual.media.title": "Nextcloud",
   "nextcloud.documents": "Documents synchronisés",
   "create.nextcloud.documents": "Créer un dossier synchronisé",
   "nextcloud.quota": "Espace utilisé synchronisé",

--- a/src/main/resources/public/ts/nextcloud.behaviours.ts
+++ b/src/main/resources/public/ts/nextcloud.behaviours.ts
@@ -2,12 +2,14 @@ import {NextcloudEventService} from "./services";
 import {workspaceNextcloudFolder} from "./sniplets/workspace-nextcloud-folder.sniplet";
 import {workspaceNextcloudContent} from "./sniplets/content/workspace-nextcloud-content.sniplet";
 import rights from "./rights";
+import {MediaLibraryService} from "./sniplets/virtual-media-library";
 
 export const NEXTCLOUD_APP = "nextcloud";
 
 export const nextcloudBehaviours = {
     rights: rights,
     nextcloudService: new NextcloudEventService,
+    mediaLibraryService: new MediaLibraryService(),
     sniplets: {
         'nextcloud-folder/workspace-nextcloud-folder': workspaceNextcloudFolder,
         'nextcloud-content/content/workspace-nextcloud-content': workspaceNextcloudContent,

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -9,7 +9,7 @@ export interface INextcloudService {
     moveDocument(userid: string, path: string, destPath: string): Promise<AxiosResponse>;
     moveDocumentNextcloudToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<AxiosResponse>;
     moveDocumentWorkspaceToCloud(userid: string, ids: Array<string>, cloudDocumentName?: string): Promise<AxiosResponse>;
-    copyDocumentToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<Array<Element>>;
+    copyDocumentToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<Array<models.Element>>;
     deleteDocuments(userid: string, path: Array<string>): Promise<AxiosResponse>;
     getFile(userid: string, fileName: string, path: string, contentType: string): string;
     getFiles(userid: string, path: string, files: Array<string>): string;
@@ -55,7 +55,7 @@ export const nextcloudService: INextcloudService = {
         return http.put(`/nextcloud/files/user/${userid}/workspace/move/cloud?${urlParams}${parentDocumentNameParam}`);
     },
 
-    copyDocumentToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<Array<Element>> {
+    copyDocumentToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<Array<models.Element>> {
         let urlParams: URLSearchParams = new URLSearchParams();
         paths.forEach((path: string) => urlParams.append('path', path));
         const parentIdParam: string = parentId ? `&parentId=${parentId}` : '';

--- a/src/main/resources/public/ts/sniplets/virtual-media-library.ts
+++ b/src/main/resources/public/ts/sniplets/virtual-media-library.ts
@@ -1,0 +1,156 @@
+import {SyncDocument} from "../models";
+import {Document, FolderTreeProps, model, workspace} from "entcore";
+import {AxiosError} from "axios";
+import {nextcloudService, nextcloudUserService} from "../services";
+import {NextcloudDocumentsUtils} from "../utils/nextcloud-documents.utils";
+import rights from "../rights";
+import {WorkspaceEntcoreUtils} from "../utils/workspace-entcore.utils";
+import {Element} from "entcore/types/src/ts/workspace/model";
+import models = workspace.v2.models;
+import service = workspace.v2.service;
+
+interface IVirtualMediaLibraryScope {
+
+    /**
+     * document folder type
+     */
+    folders: Array<Document>;
+
+    /**
+     * any documents
+     */
+    documents: Array<Document>;
+
+    /**
+     * the current opened tree loaded from behaviours
+     */
+    openedTree: FolderTreeProps;
+
+    /**
+     * While initializing the service tree, this method will be implemented to any behaviours in order to enable the mediaLibraryService
+     * @returns {boolean}
+     */
+    enableInitFolderTree(): boolean;
+
+    /**
+     * Init the folder tree service behaviour's ideal
+     * **IMPORTANT**: Requires this method to populate {folders} and {documents} members
+     */
+    initFolderTree(): Promise<void>;
+
+    /**
+     * Open the folder (via tree or in the content view)
+     * **IMPORTANT**: Requires this method to populate {folders} children and {documents} children members
+     */
+    openFolder(folder: Document): Promise<void>;
+
+
+    /**
+     * This method will execute the behaviour's action before its executes the media library scope {selectDocuments()}
+     *
+     * **IMPORTANT**: Requires this method to populate {folders} children and {documents} children members
+     * @returns {Array<Document>} where all elements will be selected and assigned to media library's {documents} scope
+     * before executing media library scope {selectDocuments()}
+     *
+     * @example
+     * in one module's behaviour, we implement onSelectVirtualDocumentsBefore() on which we call an API service to duplicate the document and return
+     * the wished documents to be assigned
+     *
+     * Another example would be to call an API or any other method
+     * in the end, this shall return a "truth" document with truth id to be interacted for the {selectDocuments()}
+     *
+     * @param documents selected documents used to "materialize" into documents
+     */
+    onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>>;
+
+    /**
+     * (optional) Allows clear copied documents (if you decided in your method {onSelectVirtualDocumentsBefore()})
+     * to duplicate your selected document or entities and returns new documents within
+     *
+     * @param documents selected documents
+     */
+    clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void>;
+}
+
+export class MediaLibraryService implements IVirtualMediaLibraryScope {
+    openedTree: any;
+    folders: Array<Document>;
+    documents: Array<Document>;
+
+    constructor() {
+        this.folders = [];
+        this.documents = [];
+    }
+
+    enableInitFolderTree(): boolean {
+        if (model.me.hasWorkflow(rights.workflow.access)) {
+            nextcloudUserService.resolveUser(model.me.userId);
+            this.registerNextcloudThumbUrlMapper();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private registerNextcloudThumbUrlMapper(): void {
+        const nextcloudFunction = (element: Element) => {
+            if (element.application === "nextcloud") {
+                return nextcloudService.getFile(model.me.userId, <any>element.name, (<any>element).path, <any>element.contentType);
+            }
+        }
+        models.Element.registerThumbUrlMapper(nextcloudFunction);
+    }
+
+    async initFolderTree(): Promise<void> {
+        let syncDocuments: Array<SyncDocument> = await nextcloudService.listDocument(model.me.userId, null)
+            .catch((err: AxiosError) => {
+                const message: string = "Error while attempting to fetch documents children ";
+                console.error(message + err.message);
+                return [];
+            });
+
+        // populate folder content to media library behaviours
+        this.folders = (<any>syncDocuments)
+            .filter(NextcloudDocumentsUtils.filterRemoveNameFile())
+            .filter(NextcloudDocumentsUtils.filterDocumentOnly());
+
+        // populate file content to media library behaviours
+        this.documents =  WorkspaceEntcoreUtils.toDocuments(
+            (<any>syncDocuments)
+                .filter(NextcloudDocumentsUtils.filterRemoveNameFile())
+                .filter(NextcloudDocumentsUtils.filterFilesOnly())
+        );
+    }
+
+    async openFolder(folder: models.Element): Promise<void> {
+        let syncDocuments: Array<SyncDocument> = await nextcloudService.listDocument(model.me.userId, (<any>folder).path ? (<any>folder).path : null)
+            .catch((err: AxiosError) => {
+                const message: string = "Error while attempting to fetch documents children ";
+                console.error(message + err.message);
+                return [];
+            });
+
+        // first filter applies only when we happen to fetch its own folder and the second applies on document only
+        (<any>this.folders) = syncDocuments
+            .filter(NextcloudDocumentsUtils.filterRemoveOwnDocument((<any>folder)))
+            .filter(NextcloudDocumentsUtils.filterDocumentOnly());
+
+        (<any>this.documents) = WorkspaceEntcoreUtils.toDocuments(
+            syncDocuments
+                .filter(NextcloudDocumentsUtils.filterRemoveOwnDocument((<any>folder)))
+                .filter(NextcloudDocumentsUtils.filterFilesOnly())
+        );
+    }
+
+    async onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>> {
+        const paths: Array<string> = (documents as Array<SyncDocument>).map((doc: SyncDocument) => doc.path);
+        return nextcloudService.copyDocumentToWorkspace(model.me.userId, paths)
+            .then((res: Array<models.Element>) => res.map(d => new Document(d)));
+    }
+
+    async clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void> {
+        if (documents && documents.length)
+            service.deleteAll(documents);
+    }
+
+}

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -12,6 +12,7 @@ import {INextcloudUserService, nextcloudUserService} from "../services";
 import {UserNextcloud} from "../models/nextcloud-user.model";
 import {Subscription} from "rxjs";
 import rights from "../rights";
+import {NextcloudDocumentsUtils} from "../utils/nextcloud-documents.utils";
 
 declare let window: any;
 
@@ -178,23 +179,14 @@ class ViewModel implements IViewModel {
                 return [];
         });
         // first filter applies only when we happen to fetch its own folder and the second applies on document only
-        document.children = syncDocuments.filter(this.filterRemoveOwnDocument(document)).filter(this.filterDocumentOnly());
+        document.children = syncDocuments.filter(NextcloudDocumentsUtils.filterRemoveOwnDocument(document)).filter(NextcloudDocumentsUtils.filterDocumentOnly());
         safeApply(this.scope);
 
         Behaviours.applicationsBehaviours[NEXTCLOUD_APP].nextcloudService
             .sendDocuments({
                 parentDocument: document.path ? document : new SyncDocument().initParent(),
-                documents: syncDocuments.filter(this.filterRemoveOwnDocument(document))
+                documents: syncDocuments.filter(NextcloudDocumentsUtils.filterRemoveOwnDocument(document))
             });
-    }
-
-    /* Filter mode */
-    private filterDocumentOnly() {
-        return (syncDocument: SyncDocument) => syncDocument.isFolder && syncDocument.name != model.me.userId;
-    }
-
-    private filterRemoveOwnDocument(document: SyncDocument) {
-        return (syncDocument: SyncDocument) => syncDocument.path !== document.path;
     }
 
     setSwitchDisplayHandler(): void {

--- a/src/main/resources/public/ts/utils/nextcloud-documents.utils.ts
+++ b/src/main/resources/public/ts/utils/nextcloud-documents.utils.ts
@@ -1,0 +1,26 @@
+import {SyncDocument} from "../models";
+import {model} from "entcore";
+
+export class NextcloudDocumentsUtils {
+
+    static filterRemoveNameFile(): (syncDocument: SyncDocument) => boolean {
+        return (syncDocument: SyncDocument) => syncDocument.name !== model.me.userId;
+    }
+
+    static filterDocumentOnly(): (syncDocument: SyncDocument) => boolean {
+        return (syncDocument: SyncDocument) => syncDocument.isFolder && syncDocument.name != model.me.userId;
+    }
+
+    static filterFilesOnly(): (syncDocument: SyncDocument) => boolean {
+        return (syncDocument: SyncDocument) => !syncDocument.isFolder && syncDocument.name != model.me.userId;
+    }
+
+    static filterRemoveOwnDocument(document: SyncDocument): (syncDocument: SyncDocument) => boolean {
+        return (syncDocument: SyncDocument) => syncDocument.path !== document.path;
+    }
+
+    static getExtension(filename: string): string {
+        let words: Array<string> = filename.split(".");
+        return words[words.length - 1];
+    }
+}

--- a/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
+++ b/src/main/resources/public/ts/utils/workspace-entcore.utils.ts
@@ -1,5 +1,8 @@
-import {angular, Folder, workspace} from "entcore";
+import {angular, Document, Folder, model, workspace} from "entcore";
 import models = workspace.v2.models;
+import {SyncDocument} from "../models";
+import {NextcloudDocumentsUtils} from "./nextcloud-documents.utils";
+
 import WorkspaceEvent = workspace.v2.WorkspaceEvent;
 export class WorkspaceEntcoreUtils {
 
@@ -65,5 +68,29 @@ export class WorkspaceEntcoreUtils {
             }
             workspace.v2.service.onChange.next(event);
         }
+    }
+
+    static toDocuments(syncDocuments: Array<SyncDocument>): Array<Document> {
+        let formattedDocuments: Array<Document> = [];
+        syncDocuments.forEach((syncDoc: SyncDocument) => {
+            let elementObj: any = {
+                name: syncDoc.name,
+                comments: '',
+                metadata: {
+                    'content-type': syncDoc.contentType,
+                    role: syncDoc.role,
+                    extension: NextcloudDocumentsUtils.getExtension(syncDoc.name),
+                    filename: syncDoc.name,
+                    size: syncDoc.size
+                },
+                owner: model.me.userId,
+                ownerName: syncDoc.ownerDisplayName,
+                path: syncDoc.path
+            };
+            let newElement: Document = new Document(elementObj);
+            newElement.application = "nextcloud";
+            formattedDocuments.push(newElement);
+        });
+        return formattedDocuments;
     }
 }


### PR DESCRIPTION
## Describe your changes
Reprend la PR https://github.com/CGI-OPEN-ENT-NG/infra-front/pull/7 

Cette PR utilise l'implémentation de virtual folder pour que le composant media-library

[DRAFT] Une version sur l'entcore du package.json sera modifié pour ajouté le composant virtual folder

## Checklist tests

Prerequis config (tech part) : 
- [x] Suivre la doc dans le readme indiqué dans la PR https://github.com/CGI-OPEN-ENT-NG/infra-front/pull/7 
       - [ ] Config public-conf de workspace rajout "nextcloud" dans `folder-service` 
       - [ ] (optionel) ajouté la version ciblé de virtual-folder-rc dans le package.json

- [x] Utiliser l'ajout d'une pièce jointe ou éditeur riche depuis un module (actualité par exemple) 
- [x] Pouvoir voir son arborescence (nextcloud dans notre cas)
- [x] Quand on va dans l'arborescence, on peut naviguer à travers les documents et dossiers (les extensions sont filtré en fonction du composant)
- [x] Quand on sélectionne un document, le comportement devrait être le même que quand on sélectionne un document depuis l'arborescence "normal"

## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/DRIV-26

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

