### PR TITLE
fix(move): #DRIV-38 move from nextcloud to workspace now select the right folder in the tree

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -156,6 +156,8 @@ class ViewModel implements IViewModel {
                             this.documents = syncedDocument
                                 .filter((syncDocument: SyncDocument) => syncDocument.path != selectedFolderFromNextcloudTree.path)
                                 .filter((syncDocument: SyncDocument) => syncDocument.name != model.me.userId);
+                            Behaviours.applicationsBehaviours[NEXTCLOUD_APP].nextcloudService.setContentContext(null);
+                            Behaviours.applicationsBehaviours[NEXTCLOUD_APP].nextcloudService.sendOpenFolderDocument(selectedFolderFromNextcloudTree);
                             this.safeApply();
                         })
                         .catch((err: AxiosError) => {

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -81,12 +81,7 @@ class ViewModel implements IViewModel {
         this.subscriptions.add(Behaviours.applicationsBehaviours[NEXTCLOUD_APP].nextcloudService
             .getOpenedFolderDocument()
             .subscribe((document: SyncDocument) => {
-                this.folderTree.openFolder(document)
-                    .then(() => {
-                        safeApply(scope);
-                    });
-
-
+                this.folderTree.openFolder(document);
             }));
 
     }

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -30,8 +30,8 @@ interface IViewModel {
 
     userInfo: UserNextcloud;
     folderTree: FolderTreeProps;
-    selectedFolder:any | models.Element;
-    openedFolder: Array<any | models.Element>;
+    selectedFolder: models.Element;
+    openedFolder: Array<models.Element>;
 
     // drag & drop actions
     initDraggable(): void;
@@ -47,7 +47,7 @@ class ViewModel implements IViewModel {
     userInfo: UserNextcloud;
     folderTree: FolderTreeProps;
     selectedFolder: models.Element;
-    openedFolder: Array<any |models.Element> = [];
+    openedFolder: Array<models.Element> = [];
     droppable: Draggable;
     documents: Array<SyncDocument>;
 
@@ -83,7 +83,6 @@ class ViewModel implements IViewModel {
             .subscribe((document: SyncDocument) => {
                 this.folderTree.openFolder(document)
                     .then(() => {
-                        this.folderTree.setSelectedFolder(document);
                         safeApply(scope);
                     });
 
@@ -111,16 +110,13 @@ class ViewModel implements IViewModel {
             isSelectedFolder(folder: models.Element): boolean {
                 return viewModel.selectedFolder === folder;
             },
-            setSelectedFolder(folder : models.Element): void {
-                viewModel.selectedFolder = folder;
-            },
-            async openFolder(folder: any | models.Element): Promise<void> {
+            async openFolder(folder: models.Element): Promise<void> {
                 viewModel.setSwitchDisplayHandler();
                 // create handler in case icon are only clicked
                 viewModel.selectedFolder = folder;
                 viewModel.watchFolderState();
                 if (!viewModel.openedFolder.some((openFolder: models.Element) => openFolder === folder)) {
-                    viewModel.openedFolder = viewModel.openedFolder.filter(e => e.path != folder.path);
+                    viewModel.openedFolder = viewModel.openedFolder.filter(e => (<any> e).path != (<any> folder).path);
                     viewModel.openedFolder.push(folder);
                 }
                 // synchronize documents and send content to its other sniplet content
@@ -249,7 +245,6 @@ class ViewModel implements IViewModel {
             // go back to workspace content display
             // clear nextCloudTree interaction
             viewModel.selectedFolder = null;
-            // console.log(arguments[0].currentTarget);
             arguments[0].target.classList.add('selected');
             // update workspace folder content
             WorkspaceEntcoreUtils.updateWorkspaceDocuments(angular.element(arguments[0].target).scope().folder);

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -111,7 +111,7 @@ class ViewModel implements IViewModel {
                 viewModel.selectedFolder = folder;
                 viewModel.watchFolderState();
                 if (!viewModel.openedFolder.some((openFolder: models.Element) => openFolder === folder)) {
-                    viewModel.openedFolder = viewModel.openedFolder.filter(e => (<any> e).path != (<any> folder).path);
+                    viewModel.openedFolder = viewModel.openedFolder.filter((e: models.Element) => (<any> e).path != (<any> folder).path);
                     viewModel.openedFolder.push(folder);
                 }
                 // synchronize documents and send content to its other sniplet content


### PR DESCRIPTION
…
## Describe your changes
Following of #40, when we dropped files from nextcloud to workspace, and then clicked in the workspace tree, the selected folder was not the right one, it was the parent folder.
The fix main fix was to update manually the openedFolder in the scope.
## Checklist tests
Tested on browser (EDGE). 
## Issue ticket number and link
[ DRIV-38 ]
https://entsupport.gdapublic.fr/browse/DRIV-38
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

