### PR TITLE
feat(url): #DRIV-42 add nextcloud url display into workspace

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/NextcloudController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/NextcloudController.java
@@ -1,22 +1,30 @@
 package fr.openent.nextcloud.controller;
 
+import fr.openent.nextcloud.config.NextcloudConfig;
+import fr.openent.nextcloud.core.constants.Field;
 import fr.openent.nextcloud.core.constants.WorkflowRight;
+import fr.openent.nextcloud.security.Access;
 import fr.openent.nextcloud.service.ServiceFactory;
 import fr.wseduc.rs.ApiDoc;
 import fr.wseduc.rs.Get;
+import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.http.Renders;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
+import org.entcore.common.http.filter.ResourceFilter;
 
 public class NextcloudController extends ControllerHelper {
 
     private final EventStore eventStore;
+    private final NextcloudConfig nextcloudConfig;
 
     public NextcloudController(ServiceFactory serviceFactory) {
         this.eventStore = EventStoreFactory.getFactory().getEventStore(fr.openent.nextcloud.Nextcloud.class.getSimpleName());
+        this.nextcloudConfig = serviceFactory.nextcloudConfig();
     }
 
     @Get("")
@@ -24,5 +32,13 @@ public class NextcloudController extends ControllerHelper {
     @SecuredAction(WorkflowRight.VIEW)
     public void view(HttpServerRequest request) {
         Renders.notFound(request);
+    }
+
+    @Get("/config/url")
+    @ApiDoc("Fetch Nextcloud url")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(Access.class)
+    public void getNextcloudUrl(HttpServerRequest request) {
+        Renders.renderJson(request, new JsonObject().put(Field.URL, nextcloudConfig.host()));
     }
 }

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -46,6 +46,7 @@ public class Field {
     public static final String DIR = "dir";
     public static final String DESTINATION = "destination";
     public static final String ERROR = "error";
+    public static final String URL = "url";
 
 
     public static final String STATUS = "status";

--- a/src/main/java/fr/openent/nextcloud/security/Access.java
+++ b/src/main/java/fr/openent/nextcloud/security/Access.java
@@ -1,0 +1,16 @@
+package fr.openent.nextcloud.security;
+
+import fr.openent.nextcloud.core.enums.WorkflowActions;
+import fr.openent.nextcloud.helper.WorkflowHelper;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+public class Access implements ResourcesProvider {
+    @Override
+    public void authorize(HttpServerRequest httpServerRequest, Binding binding, UserInfos userInfos, Handler<Boolean> handler) {
+        handler.handle(WorkflowHelper.hasRight(userInfos, WorkflowActions.ACCESS.getAction()));
+    }
+}

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -4,5 +4,6 @@
   "nextcloud.documents": "Synchronized documents",
   "create.nextcloud.documents": "Create a synchronized folder",
   "nextcloud.quota": "Synchronized used space",
-  "nextcloud.file.already.exist": "Impossible to rename the file with this name: already exists"
+  "nextcloud.file.already.exist": "Impossible to rename the file with this name: already exists",
+  "nextcloud.url.connect": "To connect from your phone or computer"
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -4,5 +4,6 @@
   "nextcloud.documents": "Documents synchronisés",
   "create.nextcloud.documents": "Créer un dossier synchronisé",
   "nextcloud.quota": "Espace utilisé synchronisé",
-  "nextcloud.file.already.exist": "Impossible de renommer le fichier avec ce nom: celui-ci existe déjà"
+  "nextcloud.file.already.exist": "Impossible de renommer le fichier avec ce nom: celui-ci existe déjà",
+  "nextcloud.url.connect": "Pour se connecter depuis votre téléphone ou votre ordinateur"
 }

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -1,4 +1,9 @@
 <div id="nextcloud-content" class="sniplet nextcloud">
+    <!-- url connect -->
+    <div ng-if="vm.nextcloudUrl">
+        <i18n>nextcloud.url.connect</i18n> &#58; <a target="_blank" ng-href="[[vm.nextcloudUrl]]">[[vm.nextcloudUrl]]</a>
+    </div>
+
     <!-- dropzone action file -->
     <dropzone-overlay
             ng-if="vm.isDropzoneEnabled()"

--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -1,10 +1,25 @@
-import axios, {AxiosResponse} from 'axios';
+import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {nextcloudService} from '../nextcloud.service';
 import {IDocumentResponse} from "../../models";
-import http from "axios";
 
 describe('NextcloudService', () => {
+
+    it('test fetching nextcloud config url via axios', done => {
+        const mock = new MockAdapter(axios);
+        let spy = jest.spyOn(axios, "get");
+
+        const data = {url: "your_url"};
+
+        mock.onGet(`/nextcloud/config/url`).reply(200, data);
+
+        nextcloudService.getNextcloudUrl().then((e) => {
+            expect(spy).toHaveBeenCalledWith(`/nextcloud/config/url`);
+            expect(data.url).toEqual(e);
+            done();
+        });
+    });
+
     it('Test listDocument method', done => {
         const mock = new MockAdapter(axios);
         const iDocumentResponse1: IDocumentResponse = {

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -4,6 +4,7 @@ import {IDocumentResponse, SyncDocument} from "../models";
 import models = workspace.v2.models;
 
 export interface INextcloudService {
+    getNextcloudUrl(): Promise<string>;
     listDocument(userid: string, path?: string): Promise<Array<SyncDocument>>;
     uploadDocuments(userid: string, files: Array<File>): Promise<AxiosResponse>;
     moveDocument(userid: string, path: string, destPath: string): Promise<AxiosResponse>;
@@ -16,6 +17,10 @@ export interface INextcloudService {
 }
 
 export const nextcloudService: INextcloudService = {
+
+    getNextcloudUrl: async (): Promise<string> => {
+        return http.get(`/nextcloud/config/url`).then((res: AxiosResponse) => res.data.url);
+    },
 
     listDocument: async (userid: string, path?: string): Promise<Array<SyncDocument>> => {
         const urlParam: string = path ? `?path=${path}` : '';


### PR DESCRIPTION
## Describe your changes

Permet de mettre en évidence l'url de nextcloud pour les utilisateurs qui ONT ACCESS au Nextcloud pour basculier au client nextcloud

![image](https://user-images.githubusercontent.com/10532050/173842733-a4b502aa-dff0-46b8-9de7-ee4476af63c2.png)

Doc : https://entconf.gdapublic.fr/display/DRIV/Nextcloud+Config+API#NextcloudConfigAPI-getnextcloudconfigURL


## Checklist tests

- [x] Ne doit pas s'afficher si la conf "host" n'est pas renseigné dans le springboard
- [x] Doit s'afficher si la conf "host" est renseigné
- [x] En cas d'erreur (simuler via la console d'un navigateur une erreur), le comportement pour naviguer reste "normal"

## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/DRIV-42

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

