### PR TITLE
feat(move): #DRIV-19 move folders from WS to NC is now working

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -194,7 +194,24 @@ public class DocumentsController extends ControllerHelper {
         if (!listFiles.isEmpty())
             UserUtils.getUserInfos(eb, request, user ->
                     userService.getUserSession(user.getUserId())
-                            .compose(userSession -> documentsService.moveFilesFromWorkspaceToNC(userSession, user, listFiles, parentId))
+                            .compose(userSession -> documentsService.moveDocumentsFromWorkspaceToNC(userSession, user, listFiles, parentId))
+                            .onSuccess(res -> renderJson(request, res))
+                            .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
+        else
+            badRequest(request);
+    }
+
+    @Put("/files/user/:userid/workspace/copy/cloud")
+    @ApiDoc("Copy a file from ENT workspace to cloud")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(OwnerFilter.class)
+    public void copyToCloud(HttpServerRequest request) {
+        List<String> listFiles = request.params().getAll(Field.ID);
+        String parentId = request.params().get(Field.PARENTNAME);
+        if (!listFiles.isEmpty())
+            UserUtils.getUserInfos(eb, request, user ->
+                    userService.getUserSession(user.getUserId())
+                            .compose(userSession -> documentsService.copyDocumentsFromWorkspaceToNC(userSession, user, listFiles, parentId))
                             .onSuccess(res -> renderJson(request, res))
                             .onFailure(err -> renderError(request, new JsonObject().put(Field.ERROR, err.getMessage()))));
         else

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -32,14 +32,12 @@ public class Field {
     public static final String QUOTA = "quota";
     public static final String FREE = "free";
     public static final String APP = "nextcloud";
-    public static final String LIST = "list";
     public static final String RELATIVE = "relative";
     public static final String TOTAL = "total";
     public static final String GROUPID = "groupId";
     public static final String KEY = "key";
     public static final String FILECOUNT = "File-Count";
     public static final String VALUE = "value";
-    public static final String LISTFILES = "List-Files";
     public static final String APPPASSWORD = "apppassword";
     public static final String FILENAME = "fileName";
     public static final String FILENAMELOWER = "filename";

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -18,6 +18,7 @@ public class Field {
     public static final String EMAIL = "email";
     public static final String PHONE = "phone";
     public static final String PARENTNAME = "parentName";
+    public static final String ASCIISPACE = "%20";
     public static final String ACTION = "action";
     public static final String OWNER = "owner";
     public static final String OWNERNAME = "ownerName";

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -12,6 +12,8 @@ public class Field {
     public static final String NAME = "name";
     public static final String DISPLAYNAME = "displayname";
     public static final String YES = "yes";
+    public static final String ETYPE = "eType";
+    public static final String FOLDER = "folder";
     public static final String DISPLAYNAMECAMEL = "displayName";
     public static final String EMAIL = "email";
     public static final String PHONE = "phone";

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -30,6 +30,7 @@ public class Field {
     public static final String QUOTA = "quota";
     public static final String FREE = "free";
     public static final String APP = "nextcloud";
+    public static final String LIST = "list";
     public static final String RELATIVE = "relative";
     public static final String TOTAL = "total";
     public static final String GROUPID = "groupId";

--- a/src/main/java/fr/openent/nextcloud/core/enums/NextcloudHttpMethod.java
+++ b/src/main/java/fr/openent/nextcloud/core/enums/NextcloudHttpMethod.java
@@ -2,6 +2,7 @@ package fr.openent.nextcloud.core.enums;
 
 public enum NextcloudHttpMethod {
     PROPFIND("PROPFIND"),
+    MKCOL("MKCOL"),
     MOVE("MOVE");
 
 

--- a/src/main/java/fr/openent/nextcloud/core/enums/WorkspaceEventBusActions.java
+++ b/src/main/java/fr/openent/nextcloud/core/enums/WorkspaceEventBusActions.java
@@ -2,7 +2,9 @@ package fr.openent.nextcloud.core.enums;
 
 public enum WorkspaceEventBusActions {
     ADDFOLDER("addFolder"),
-    DELETE("delete");
+    DELETE("delete"),
+    GETDOCUMENT("getDocument"),
+    LIST("list");
 
     private final String action;
 

--- a/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
@@ -26,6 +26,14 @@ public class EventBusHelper {
         return requestJsonObject(eb, action);
     }
 
+    public static Future<JsonObject> getDocument(EventBus eb, JsonObject action) {
+        return requestJsonObject(eb, action);
+    }
+
+    public static Future<JsonArray> listDocuments(EventBus eb, JsonObject action) {
+        return requestJsonArray(eb, action);
+    }
+
     public static Future<JsonArray> deleteDocument(EventBus eb, String id, String userId) {
         JsonObject action =  new JsonObject()
                 .put(Field.ACTION, WorkspaceEventBusActions.DELETE.action())

--- a/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
+++ b/src/main/java/fr/openent/nextcloud/helper/EventBusHelper.java
@@ -14,33 +14,6 @@ import io.vertx.core.logging.LoggerFactory;
 
 public class EventBusHelper {
     private static final String WORKSPACE_BUS_ADDRESS = "org.entcore.workspace";
-    private static final Logger log = LoggerFactory.getLogger(DefaultDocumentsService.class);
-
-    /**
-     * Create a folder ine the workspace
-     * @param eb                The current eventBus
-     * @param action            The action parameters to send to the event bus
-     * @return                  Future with the status of the folder creation
-     */
-    public static Future<JsonObject> createFolder(EventBus eb, JsonObject action) {
-        return requestJsonObject(eb, action);
-    }
-
-    public static Future<JsonObject> getDocument(EventBus eb, JsonObject action) {
-        return requestJsonObject(eb, action);
-    }
-
-    public static Future<JsonArray> listDocuments(EventBus eb, JsonObject action) {
-        return requestJsonArray(eb, action);
-    }
-
-    public static Future<JsonArray> deleteDocument(EventBus eb, String id, String userId) {
-        JsonObject action =  new JsonObject()
-                .put(Field.ACTION, WorkspaceEventBusActions.DELETE.action())
-                .put(Field.ID, id)
-                .put(Field.USERID_CAPS, userId);
-        return requestJsonArray(eb, action);
-    }
 
     /**
      * Call event bus with action

--- a/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
@@ -98,12 +98,22 @@ public interface DocumentsService {
     Future<List<JsonObject>> moveDocumentToWorkspace(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> filesPath, String parentId);
 
     /**
-     * Move all the files listed in id idList from workspace to Nextcloud
+     * Move all the documents listed in id idList from workspace to Nextcloud
      * @param userSession   User session
      * @param user          User infos
-     * @param idList        Identifier of all the files to move
+     * @param idList        Identifier of all the documents to move
      * @param parentName    Name of the parent folder in nextcloud
      * @return              Future Json with all the status infos about the move.
      */
-    Future<JsonObject> moveFilesFromWorkspaceToNC(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> idList, String parentName);
+    Future<JsonObject> moveDocumentsFromWorkspaceToNC(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> idList, String parentName);
+
+    /**
+     * Copy all the documents listed in id idList from workspace to Nextcloud
+     * @param userSession   User session
+     * @param user          User infos
+     * @param idList        Identifier of all the documents to move
+     * @param parentName    Name of the parent folder in nextcloud
+     * @return              Future Json with all the status infos about the copy.
+     */
+    Future<JsonObject> copyDocumentsFromWorkspaceToNC(UserNextcloud.TokenProvider userSession, UserInfos user, List<String> idList, String parentName);
 }

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -782,10 +782,7 @@ public class DefaultDocumentsService implements DocumentsService {
     public Future<JsonObject> completeResult(Future<JsonObject> future, String id, JsonArray results) {
         Promise<JsonObject> promiseSucceed = Promise.promise();
         future
-                .onSuccess(moveStatus -> {
-                    results.add(moveStatus);
-                    promiseSucceed.complete();
-                })
+                .onSuccess(results::add)
                 .onFailure(err -> {
                     results.add(new JsonObject()
                             .put(Field.ID, id)

--- a/src/main/resources/public/ts/core/enums/documents-type.ts
+++ b/src/main/resources/public/ts/core/enums/documents-type.ts
@@ -1,0 +1,4 @@
+export enum DocumentsType {
+    FILE = 'file',
+    FOLDER = 'folder'
+}

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -13,6 +13,7 @@ import {UserNextcloud} from "../models/nextcloud-user.model";
 import {Subscription} from "rxjs";
 import rights from "../rights";
 import {NextcloudDocumentsUtils} from "../utils/nextcloud-documents.utils";
+import {DocumentsType} from "../core/enums/documents-type";
 
 declare let window: any;
 
@@ -146,7 +147,7 @@ class ViewModel implements IViewModel {
             // case drop concerns workspace but we need extra check
             const document: any = JSON.parse(event.dataTransfer.getData("application/json"));
             // check if it s a workspace document with its identifier and format file to proceed move to nextcloud
-            if (document && (document._id && document.eType === "file" || document.eType === "folder")) {
+            if (document && (document._id && document.eType === DocumentsType.FILE || document.eType === DocumentsType.FOLDER)) {
                 if (angular.element(event.target).scope().folder instanceof SyncDocument) {
                     const syncedDocument: SyncDocument = angular.element(event.target).scope().folder;
                     let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['documentList']['_documents'];

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -146,7 +146,7 @@ class ViewModel implements IViewModel {
             // case drop concerns workspace but we need extra check
             const document: any = JSON.parse(event.dataTransfer.getData("application/json"));
             // check if it s a workspace document with its identifier and format file to proceed move to nextcloud
-            if (document && (document._id && document.eType === "file")) {
+            if (document && (document._id && document.eType === "file" || document.eType === "folder")) {
                 if (angular.element(event.target).scope().folder instanceof SyncDocument) {
                     const syncedDocument: SyncDocument = angular.element(event.target).scope().folder;
                     let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['documentList']['_documents'];


### PR DESCRIPTION
## Describe your changes
Following #28 We are now able to drop folders from workspace to nextcloud.
We added the corresponding changes to the API and added the copy API too.
Documentation: https://entconf.gdapublic.fr/pages/viewpage.action?spaceKey=DRIV&title=Nextcloud+Documents+API
## Checklist tests

- [x] Drop one folder
- [x] Drop one file
- [x] Drop multiples folders
- [x] Drop multiples files
- [x] Drop multiples files and folders
- [x] Drop multiples files and folders with spaces and special characters in their names

## Issue ticket number and link
[ DRIV - 19 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-19
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

