### PR TITLE
feat(move): #DRIV-45 add move nextcloud option

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -97,6 +97,7 @@ public class DocumentsController extends ControllerHelper {
     public void moveDocuments(HttpServerRequest request) {
         String path = request.getParam(Field.PATH);
         String destPath = request.getParam(Field.DESTPATH);
+        String moveAction = request.getParam(Field.MOVEACTION);
         if ((path != null && !path.isEmpty()) && (destPath != null && !destPath.isEmpty())) {
             UserUtils.getUserInfos(eb, request, user ->
                     userService.getUserSession(user.getUserId())

--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -97,7 +97,6 @@ public class DocumentsController extends ControllerHelper {
     public void moveDocuments(HttpServerRequest request) {
         String path = request.getParam(Field.PATH);
         String destPath = request.getParam(Field.DESTPATH);
-        String moveAction = request.getParam(Field.MOVEACTION);
         if ((path != null && !path.isEmpty()) && (destPath != null && !destPath.isEmpty())) {
             UserUtils.getUserInfos(eb, request, user ->
                     userService.getUserSession(user.getUserId())

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -49,6 +49,8 @@ public class Field {
     public static final String DESTINATION = "destination";
     public static final String ERROR = "error";
     public static final String URL = "url";
+    public static final String MOVEACTION = "moveAction";
+
 
 
     public static final String STATUS = "status";

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -49,7 +49,6 @@ public class Field {
     public static final String DESTINATION = "destination";
     public static final String ERROR = "error";
     public static final String URL = "url";
-    public static final String MOVEACTION = "moveAction";
 
 
 

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -1,6 +1,7 @@
 package fr.openent.nextcloud.service.impl;
 import fr.openent.nextcloud.config.NextcloudConfig;
 import fr.openent.nextcloud.core.constants.Field;
+
 import fr.openent.nextcloud.core.enums.WorkspaceEventBusActions;
 import fr.openent.nextcloud.core.enums.NextcloudHttpMethod;
 import fr.openent.nextcloud.core.enums.XmlnsAttr;
@@ -208,22 +209,15 @@ public class DefaultDocumentsService implements DocumentsService {
     @Override
     public Future<JsonObject> moveDocument(UserNextcloud.TokenProvider userSession, String path, String destPath) {
         Promise<JsonObject> promise = Promise.promise();
+
         String endpoint = nextcloudConfig.host() + nextcloudConfig.webdavEndpoint() + "/" + userSession.userId();
-        this.listFiles(userSession, destPath)
-                .onSuccess(files -> {
-                    if (files.isEmpty()) {
-                        this.client.rawAbs(NextcloudHttpMethod.MOVE.method(), endpoint + "/" + path)
-                                .basicAuthentication(userSession.userId(), userSession.token())
-                                .putHeader(Field.DESTINATION, endpoint + "/" + destPath)
-                                .send(responseAsync -> this.onMoveDocumentHandler(responseAsync, promise));
-                    } else {
-                        promise.fail("nextcloud.file.already.exist");
-                    }
-                })
-                .onFailure(promise::fail);
+        this.client.rawAbs(NextcloudHttpMethod.MOVE.method(), endpoint + "/" + path)
+                .basicAuthentication(userSession.userId(), userSession.token())
+                .putHeader(Field.DESTINATION, endpoint + "/" + destPath)
+                .send(responseAsync -> this.onMoveDocumentHandler(responseAsync, promise));
+
         return promise.future();
     }
-
 
     /**
      * Proceed async event after HTTP MOVE documents API endpoint has been sent

--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -203,4 +203,32 @@ describe('NextcloudService', () => {
         });
     });
 
+    it('Test move document should require action param such as RENAME document/folder', done => {
+        const mock = new MockAdapter(axios);
+        const userId = "userId";
+        const expectedEndpoint: string = `/nextcloud/files/user/userId/move?path=path1&destPath=path2&moveAction=RENAME`;
+
+        let spy = jest.spyOn(axios, "put");
+        mock.onPut(expectedEndpoint).reply(200);
+
+        nextcloudService.moveDocument(userId, "path1", "path2").then(() => {
+            expect(spy).toHaveBeenCalledWith(expectedEndpoint);
+            done();
+        });
+    });
+
+    it('Test move document should require action param such as MOVE document/folder', done => {
+        const mock = new MockAdapter(axios);
+        const userId = "userId";
+        const expectedEndpoint: string = `/nextcloud/files/user/userId/move?path=path1&destPath=path2&moveAction=MOVE`;
+
+        let spy = jest.spyOn(axios, "put");
+        mock.onPut(expectedEndpoint).reply(200);
+
+        nextcloudService.moveDocument(userId, "path1", "path2").then(() => {
+            expect(spy).toHaveBeenCalledWith(expectedEndpoint);
+            done();
+        });
+    });
+
 });

--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -206,7 +206,7 @@ describe('NextcloudService', () => {
     it('Test move document should require action param such as RENAME document/folder', done => {
         const mock = new MockAdapter(axios);
         const userId = "userId";
-        const expectedEndpoint: string = `/nextcloud/files/user/userId/move?path=path1&destPath=path2&moveAction=RENAME`;
+        const expectedEndpoint: string = `/nextcloud/files/user/userId/move?path=path1&destPath=path2`;
 
         let spy = jest.spyOn(axios, "put");
         mock.onPut(expectedEndpoint).reply(200);
@@ -220,7 +220,7 @@ describe('NextcloudService', () => {
     it('Test move document should require action param such as MOVE document/folder', done => {
         const mock = new MockAdapter(axios);
         const userId = "userId";
-        const expectedEndpoint: string = `/nextcloud/files/user/userId/move?path=path1&destPath=path2&moveAction=MOVE`;
+        const expectedEndpoint: string = `/nextcloud/files/user/userId/move?path=path1&destPath=path2`;
 
         let spy = jest.spyOn(axios, "put");
         mock.onPut(expectedEndpoint).reply(200);

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -39,7 +39,7 @@ export const nextcloudService: INextcloudService = {
     },
 
     moveDocument: (userid: string, path: string, destPath: string): Promise<AxiosResponse> => {
-        let urlParam: string = `?path=${path}&destPath=${destPath}`;
+        const urlParam: string = `?path=${path}&destPath=${destPath}`;
         return http.put(`/nextcloud/files/user/${userid}/move${urlParam}`);
     },
 

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -39,7 +39,7 @@ export const nextcloudService: INextcloudService = {
     },
 
     moveDocument: (userid: string, path: string, destPath: string): Promise<AxiosResponse> => {
-        const urlParam: string = `?path=${path}&destPath=${destPath}`
+        let urlParam: string = `?path=${path}&destPath=${destPath}`;
         return http.put(`/nextcloud/files/user/${userid}/move${urlParam}`);
     },
 

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -194,9 +194,9 @@ class ViewModel implements IViewModel {
     }
 
     private async moveAllDocuments(document: SyncDocument, target: SyncDocument): Promise<AxiosResponse[]> {
-        let promises: Array<Promise<AxiosResponse>> = [];
+        const promises: Array<Promise<AxiosResponse>> = [];
         this.selectedDocuments.push(document);
-        let selectedSet: Set<SyncDocument> = new Set(this.selectedDocuments.filter((doc: SyncDocument) => !doc.isFolder));
+        const selectedSet: Set<SyncDocument> = new Set(this.selectedDocuments.filter((doc: SyncDocument) => !doc.isFolder));
         selectedSet.forEach((doc: SyncDocument) => {
             promises.push(this.nextcloudService.moveDocument(model.me.userId, doc.path, target.path + doc.name));
         });

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -169,8 +169,7 @@ class ViewModel implements IViewModel {
     private processMoveToWorkspace(folderContent: any, document: SyncDocument, selectedFolderFromNextcloudTree: SyncDocument): void {
         if (folderContent.folder instanceof models.Element) {
             const filesToMove: Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
-            const filesPath: Array<string> = Array.from(filesToMove)
-                .map((file: SyncDocument) => file.path);
+            const filesPath: Array<string> = Array.from(filesToMove).map((file: SyncDocument) => file.path);
             if (filesPath.length) {
                 this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, filesPath, folderContent.folder._id)
                     .then(() => {
@@ -200,7 +199,7 @@ class ViewModel implements IViewModel {
         selectedSet.forEach((doc: SyncDocument) => {
             promises.push(this.nextcloudService.moveDocument(model.me.userId, doc.path, target.path + doc.name));
         });
-        return await Promise.all(promises);
+        return await Promise.all<AxiosResponse>(promises);
     }
 
     private processMoveToNextcloud(document: SyncDocument, target: SyncDocument, selectedFolderFromNextcloudTree: SyncDocument): void {

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -160,7 +160,7 @@ class ViewModel implements IViewModel {
             this.processMoveToWorkspace(folderContent, document, selectedFolderFromNextcloudTree);
         }
         // if interacted into nextcloud (folderContent as being te targeted path to move in)
-        if (folderContent.content instanceof SyncDocument && folderContent.content.isFolder) {
+        if (folderContent && folderContent.content instanceof SyncDocument && folderContent.content.isFolder) {
             // if interacted into nextcloud
             this.processMoveToNextcloud(document, folderContent.content, selectedFolderFromNextcloudTree);
         }
@@ -168,12 +168,12 @@ class ViewModel implements IViewModel {
 
     private processMoveToWorkspace(folderContent: any, document: SyncDocument, selectedFolderFromNextcloudTree: SyncDocument): void {
         if (folderContent.folder instanceof models.Element) {
-            let fileToMove: Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
-            let finalUpload: Array<string> = Array.from(fileToMove)
+            const filesToMove: Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
+            const filesPath: Array<string> = Array.from(filesToMove)
                 .map((file: SyncDocument) => file.path);
-            if (finalUpload.length) {
-                this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, finalUpload, folderContent.folder._id)
-                    .then(async (_: AxiosResponse) => {
+            if (filesPath.length) {
+                this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, filesPath, folderContent.folder._id)
+                    .then(() => {
                         return nextcloudService.listDocument(model.me.userId, selectedFolderFromNextcloudTree.path ?
                             selectedFolderFromNextcloudTree.path : null);
                     })
@@ -205,7 +205,8 @@ class ViewModel implements IViewModel {
 
     private processMoveToNextcloud(document: SyncDocument, target: SyncDocument, selectedFolderFromNextcloudTree: SyncDocument): void {
             this.moveAllDocuments(document, target)
-            .then(async (_: AxiosResponse[]) => {
+            .then(() => {
+                this.selectedDocuments = [];
                 return nextcloudService.listDocument(model.me.userId, selectedFolderFromNextcloudTree.path ?
                     selectedFolderFromNextcloudTree.path : null);
             })


### PR DESCRIPTION
## Describe your changes
Context: We wanted to add the possibility to move a file within nextcloud's forlders.

https://user-images.githubusercontent.com/101819152/176392864-caa246ab-a367-46c1-a8ea-92664bbc4911.mp4


It is now possible to move a nextcloud file into a nextcloud folder. It is working as the rename option.
If the file name already exists in the target folder, the operation will fail.
## Checklist tests

- [x] Move one file into a folder
- [x] Move multiples files into a folder

## Issue ticket number and link
[ DRIV-45 ]
https://entsupport.gdapublic.fr/projects/DRIV/issues/DRIV-45
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

