### PR TITLE
fix(delete): #DRIV-23 delete folders now update tree

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -120,6 +120,12 @@ class ViewModel implements IViewModel {
         safeApply(this.scope);
     }
 
+    updateTree(): void {
+        const selectedFolderFromNextcloudTree: SyncDocument = this.getNextcloudTreeController()['selectedFolder'];
+        this.updateFolderDocument(selectedFolderFromNextcloudTree);
+        this.safeApply();
+    }
+
     initDraggable(): void {
         // use this const to make it accessible to its folderTree inner context
         const viewModel: IViewModel = this;

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
@@ -121,6 +121,7 @@ export class ToolbarSnipletViewModel implements IViewModel {
     }
 
     deleteDocuments(): void {
+        const selectedFolderFromNextcloudTree: SyncDocument = this.vm.getNextcloudTreeController()['selectedFolder'];
         const paths: Array<string> = this.vm.selectedDocuments.map((selectedDocument: SyncDocument) => selectedDocument.path);
         this.vm.nextcloudService.deleteDocuments(model.me.userId, paths)
             .then(() => {
@@ -133,6 +134,7 @@ export class ToolbarSnipletViewModel implements IViewModel {
                     .filter((syncDocument: SyncDocument) => syncDocument.name != model.me.userId);
                 this.toggleDeleteView(false);
                 this.vm.selectedDocuments = [];
+                this.vm.updateFolderDocument(selectedFolderFromNextcloudTree);
                 safeApply(this.scope);
             })
             .catch((err: AxiosError) => {

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
@@ -95,6 +95,7 @@ export class ToolbarSnipletViewModel implements IViewModel {
                         .filter((syncDocument: SyncDocument) => syncDocument.path != this.vm.parentDocument.path)
                         .filter((syncDocument: SyncDocument) => syncDocument.name != model.me.userId);
                     this.toggleRenameView(false);
+                    this.vm.updateTree();
                     this.vm.selectedDocuments = [];
                     safeApply(this.scope);
                 })
@@ -121,7 +122,6 @@ export class ToolbarSnipletViewModel implements IViewModel {
     }
 
     deleteDocuments(): void {
-        const selectedFolderFromNextcloudTree: SyncDocument = this.vm.getNextcloudTreeController()['selectedFolder'];
         const paths: Array<string> = this.vm.selectedDocuments.map((selectedDocument: SyncDocument) => selectedDocument.path);
         this.vm.nextcloudService.deleteDocuments(model.me.userId, paths)
             .then(() => {
@@ -134,7 +134,7 @@ export class ToolbarSnipletViewModel implements IViewModel {
                     .filter((syncDocument: SyncDocument) => syncDocument.name != model.me.userId);
                 this.toggleDeleteView(false);
                 this.vm.selectedDocuments = [];
-                this.vm.updateFolderDocument(selectedFolderFromNextcloudTree);
+                this.vm.updateTree();
                 safeApply(this.scope);
             })
             .catch((err: AxiosError) => {


### PR DESCRIPTION
## Describe your changes
Context: we wanted the tree to be updated when we deleted, moved and renamed folders from nextcloud
Follwing #8 We added the update in the two functions rename and remove and delete. 
The tree is now updated.
## Checklist tests
- [x] Rename folder into nextcloud
- [x] Move folder from Nextcloud to Workspace 
- [x] Delete folder from nextcloud
## Issue ticket number and link
[ DRIV-23 ]
https://entsupport.gdapublic.fr/browse/DRIV-23
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

