### PR TITLE
fix(switch): #DRIV-48 select folder in workspace is now working

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -241,7 +241,7 @@ class ViewModel implements IViewModel {
             // go back to workspace content display
             // clear nextCloudTree interaction
             viewModel.selectedFolder = null;
-            arguments[0].target.classList.add('selected');
+            arguments[0].currentTarget.classList.add('selected');
             // update workspace folder content
             WorkspaceEntcoreUtils.updateWorkspaceDocuments(angular.element(arguments[0].target).scope().folder);
             //set the right openedFolder


### PR DESCRIPTION
## Describe your changes
We updated the target of the HTML class update, as a result the right element is selected in the workspace tree.
## Checklist tests
- [x] Switch from nextcloud tree to workspace tree
## Issue ticket number and link
[ DRIV-48 ]
https://entsupport.gdapublic.fr/browse/DRIV-48
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

