### PR TITLE
fix(move): #DRIV-19 select multiples folders for move is now working

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -152,6 +152,7 @@ class ViewModel implements IViewModel {
                 if (angular.element(event.target).scope().folder instanceof SyncDocument) {
                     const syncedDocument: SyncDocument = angular.element(event.target).scope().folder;
                     let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['documentList']['_documents'];
+                    selectedDocuments = selectedDocuments.concat(WorkspaceEntcoreUtils.workspaceScope()['currentTree']['children']);
                     let documentToUpdate: Set<string> = new Set(selectedDocuments.filter((file: Document) => file.selected).map((file: Document) => file._id));
                     documentToUpdate.add(document._id);
                     nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, Array.from(documentToUpdate), syncedDocument.path)


### PR DESCRIPTION
## Describe your changes
Add selected folders in the move API call id list. Bedore folders was not supported for move, so the front was ignoring them.
## Checklist tests
- [x] Move one folder from Workspace to Nextcloud
- [x] Move multiples folders from Workspace to Nextcloud
- [x] Move multiples files and folders from Workspace to Nextcloud
## Issue ticket number and link
[ DRIV-19 ]
https://entsupport.gdapublic.fr/browse/DRIV-19
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

