### PR TITLE
fix(move): #DRIV-19 move folder now update nextcloud tree

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -156,8 +156,13 @@ class ViewModel implements IViewModel {
                     let documentToUpdate: Set<string> = new Set(selectedDocuments.filter((file: Document) => file.selected).map((file: Document) => file._id));
                     documentToUpdate.add(document._id);
                     nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, Array.from(documentToUpdate), syncedDocument.path)
-                        .then((_: AxiosResponse) => WorkspaceEntcoreUtils.updateWorkspaceDocuments(
-                            WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folder'])
+                        .then((_: AxiosResponse) => {
+                            WorkspaceEntcoreUtils.updateWorkspaceDocuments(
+                                    WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folder']);
+                            Behaviours.applicationsBehaviours[NEXTCLOUD_APP].nextcloudService.sendOpenFolderDocument(angular.element(event.target).scope().folder);
+                            this.selectedFolder = null;
+                            angular.element(event.target).scope().folder.classList.remove("selected");
+                            }
                         )
                         .catch((err: AxiosError) => {
                             const message: string = "Error while attempting to fetch documents children ";


### PR DESCRIPTION
## Describe your changes
Following #47, before this update, moving a folder from workspace to nextcloud was not applying the update to the nextcloud tree.

- [x] Move one folder from workspace to nextcloud 
- [x] Move multiples folders from workspace to nextcloud
## Issue ticket number and link
[ DRIV-19 ]
https://entsupport.gdapublic.fr/browse/DRIV-19

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

