### PR TITLE
fix(share): #DRIV-40 share file without copy now update view

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
@@ -46,6 +46,7 @@ export class ToolbarShareSnipletViewModel implements IViewModel {
         this.vm.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, paths)
             .then((workspaceDocuments: Array<models.Element>) => {
                 this.sharedElement = workspaceDocuments;
+                this.vm.updateTree();
                 const pathTemplate: string = `../../../${RootsConst.template}/behaviours/sniplet-nextcloud-content/toolbar/share/share`;
                 template.open('workspace-nextcloud-toolbar-share', pathTemplate);
             });


### PR DESCRIPTION
## Describe your changes
Share a file is now updating the view. Before this update sharing a file was not updating the nextcloud folder view.
## Checklist tests
- [x] Sharing a file without copy
## Issue ticket number and link
[ DRIV-40 ] 
https://entsupport.gdapublic.fr/browse/DRIV-40
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

