### PR TITLE
feat(move): #DRIV-57 move folder under a parent folder in NC is working

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -214,9 +214,11 @@ class ViewModel implements IViewModel {
     private async moveAllDocuments(document: SyncDocument, target: SyncDocument): Promise<AxiosResponse[]> {
         const promises: Array<Promise<AxiosResponse>> = [];
         this.selectedDocuments.push(document);
-        const selectedSet: Set<SyncDocument> = new Set(this.selectedDocuments.filter((doc: SyncDocument) => !doc.isFolder));
+        const selectedSet: Set<SyncDocument> = new Set(this.selectedDocuments);
         selectedSet.forEach((doc: SyncDocument) => {
-            promises.push(this.nextcloudService.moveDocument(model.me.userId, doc.path, (target.path != null ? target.path : "") + doc.name));
+            if (doc.path != target.path) {
+                promises.push(this.nextcloudService.moveDocument(model.me.userId, doc.path, (target.path != null ? target.path : "") + doc.name));
+            }
         });
         return await Promise.all<AxiosResponse>(promises);
     }


### PR DESCRIPTION
## Describe your changes
Following #56, move from nextcloud to nextcloud is now available for folder.
## Checklist tests
- [x] Move one folder under an other folder from NC to NC
- [x] Move one folder under the root folder from NC to NC
- [x] Move multiples folders under an other folder from NC to NC 
## Issue ticket number and link
[ DRIV-57 ]
https://entsupport.gdapublic.fr/browse/DRIV-57
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

