### PR TITLE
fix(empty-state): #DRIV-58 add css empty state nextcloud

### DIFF
--- a/src/main/resources/public/sass/global/components/sniplets/_nextcloud-content.scss
+++ b/src/main/resources/public/sass/global/components/sniplets/_nextcloud-content.scss
@@ -4,4 +4,16 @@
       object-fit: cover;
     }
   }
+  .emptyscreen {
+    &-nextcloud {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-content: center;
+      text-align: center;
+      height: inherit;
+      align-items: center;
+      margin-top: 25px;
+    }
+  }
 }

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -49,7 +49,7 @@
     </article>
 
     <!-- empty state -->
-    <div class="emptyscreen" ng-if="vm.isLoaded" ng-show="!vm.documents.length">
+    <div class="emptyscreen-nextcloud" ng-if="vm.isLoaded" ng-show="!vm.documents.length">
         <h2 class="emptyscreen-header">
             <i18n>empty.workspace.subfolder.title</i18n>
         </h2>


### PR DESCRIPTION
## Describe your changes
Open an empty folder in Nextcloud now display an emptyscreen if the folder is empty.
## Checklist tests
- [x] Open an empty folder and check if the screen display
## Issue ticket number and link
[ Driv-58 ]
https://entsupport.gdapublic.fr/browse/DRIV-58
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

