### PR TITLE
fix(toolbar): #DRIV-56 toggle toolbar display is now working

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -227,6 +227,10 @@ class ViewModel implements IViewModel {
 
             // using nextcloud content display
             template.open('documents', `../../../${RootsConst.template}/behaviours/workspace-nextcloud`);
+            let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['documents'];
+            let folders: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folders'];
+            selectedDocuments.forEach(doc => doc.selected = false);
+            folders.forEach(fol => fol.selected = false);
 
             // clear all potential "selected" class workspace folder tree
             $workspaceFolderTree.each((index: number, element: Element): void => element.classList.remove("selected"));

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -37,6 +37,7 @@ interface IViewModel {
     // drag & drop actions
     initDraggable(): void;
     resolveDragTarget(event: DragEvent): Promise<void>;
+    removeSelectedDocuments(): void;
     droppable: Draggable;
 }
 
@@ -215,6 +216,17 @@ class ViewModel implements IViewModel {
     }
 
     /**
+     * remove all the selected folders and documents of workspace
+     */
+    removeSelectedDocuments(): void {
+        let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['documents'];
+        let folders: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folders'];
+        if (selectedDocuments != null && folders != null) {
+            selectedDocuments.forEach((doc: Document) => doc.selected = false);
+            folders.forEach((fol: Document) => fol.selected = false);
+        }
+    }
+    /**
      * Remove workspace tree and use nextcloud tree instead.
      */
     private switchWorkspaceTreeHandler() {
@@ -227,14 +239,8 @@ class ViewModel implements IViewModel {
 
             // using nextcloud content display
             template.open('documents', `../../../${RootsConst.template}/behaviours/workspace-nextcloud`);
-            let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['documents'];
-            let folders: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folders'];
-            if (selectedDocuments != null && folders != null) {
-                selectedDocuments.forEach((doc: Document) => doc.selected = false);
-                folders.forEach((fol: Document) => fol.selected = false);
-            }
 
-
+            viewModel.removeSelectedDocuments();
             // clear all potential "selected" class workspace folder tree
             $workspaceFolderTree.each((index: number, element: Element): void => element.classList.remove("selected"));
             // hide workspace progress bar

--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -229,8 +229,11 @@ class ViewModel implements IViewModel {
             template.open('documents', `../../../${RootsConst.template}/behaviours/workspace-nextcloud`);
             let selectedDocuments: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['documents'];
             let folders: Array<Document> = WorkspaceEntcoreUtils.workspaceScope()['openedFolder']['folders'];
-            selectedDocuments.forEach(doc => doc.selected = false);
-            folders.forEach(fol => fol.selected = false);
+            if (selectedDocuments != null && folders != null) {
+                selectedDocuments.forEach((doc: Document) => doc.selected = false);
+                folders.forEach((fol: Document) => fol.selected = false);
+            }
+
 
             // clear all potential "selected" class workspace folder tree
             $workspaceFolderTree.each((index: number, element: Element): void => element.classList.remove("selected"));


### PR DESCRIPTION
## Describe your changes
Updated selected folders and document from workspace so the toolbar no longer persists when we swipe to nextcloud context.
## Checklist tests
- [x] select a folder in workspace and switch to nextcloud
- [x] select a document in workspace and switch to nextcloud

## Issue ticket number and link
[ DRIV-58 ]
https://entsupport.gdapublic.fr/browse/DRIV-58
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

