### PR TITLE
fix(tree): #DRIV-58 switch context is now working for subfolders

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -235,7 +235,7 @@ class ViewModel implements IViewModel {
             if (!viewModel.selectedFolder) {
                 viewModel.folderTree.openFolder(viewModel.documents[0]);
             }
-            const $workspaceFolderTree: JQuery = $(WorkspaceEntcoreUtils.$ENTCORE_WORKSPACE + ' li > a');
+            const $workspaceFolderTree: JQuery = $(WorkspaceEntcoreUtils.$ENTCORE_WORKSPACE).find('li a');
 
             // using nextcloud content display
             template.open('documents', `../../../${RootsConst.template}/behaviours/workspace-nextcloud`);


### PR DESCRIPTION
## Describe your changes
When you switch from nextcloud to workspace subfolders, the view is now working and not displaying anymore wrong files.
## Checklist tests
- [x] Switch from nextcloud context to workspace subfolders
## Issue ticket number and link
[ DRIV-58 ]
https://entsupport.gdapublic.fr/browse/DRIV-58
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

