### PR TITLE
fix(drag): #DRIV-59 add drag over feedback

### DIFF
--- a/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/workspace-nextcloud-folder.sniplet.ts
@@ -133,8 +133,9 @@ class ViewModel implements IViewModel {
                 // synchronize documents and send content to its other sniplet content
                 await viewModel.openDocument(folder);
 
-                // reset drag feedback
+                // reset drag feedback by security
                 viewModel.removeDragFeedback();
+                // init drag over
                 viewModel.addDragFeedback();
             },
         };


### PR DESCRIPTION
## Describe your changes

Vu que l'on n'a pas accès au composant folder-tree, j'ai ajouté un event listener au survol de chaque dossier pour ajouter la classe `.droptarget`. Afin de garantir que le feedback est présent sur chaque sous-dossier la fonction est appelée à chaque changement de dossier (en détruisant les anciens listeners puis en les recréant). 

## Checklist tests
Glisser un fichier/dossier dans un des dossiers de "Documents synchronisés", une bordure en pointillé orange va apparaitre autour du dossier en question.

## Issue ticket number and link

[DRIV-59](https://jira.support-ent.fr/browse/DRIV-59)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
