### PR TITLE
fix(icons): #DRIV-68 display icons depending on file role is now working

### DIFF
--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -37,13 +37,16 @@
                     </div>
                 </div>
 
-                <!-- folder format -->
-                <div ng-switch-when="folder">
-                    <i class="folder-large"></i>
+                <div ng-switch-when="video" class="twelve cell video"
+                     ng-style="{'background-image': videoThumbUrl(document)}">
+                    <i>
+                        <svg class="icon-video" width="40" height="40">
+                            <use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use>
+                        </svg>
+                    </i>
                 </div>
-                
-                <!-- default file todo pdf-large is example but also unknown-large -->
-                <i ng-switch-default class="unknown-large"></i>
+
+                <i ng-switch-default class="[[content.role]]-large"></i>
             </a>
         </explorer>
     </article>

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -40,6 +40,8 @@
                 <div class="img video" ng-switch-when="video">
                     <i><svg class="icon-video" width="40" height="40"><use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use></svg></i>
                 </div>
+                <i ng-switch-when="presentation" class="ppt-large"></i>
+                <i ng-switch-when="spreadsheet" class="xls-large"></i>
                 <i ng-switch-default class="[[content.role]]-large"></i>
             </a>
         </explorer>

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -37,13 +37,8 @@
                     </div>
                 </div>
 
-                <div ng-switch-when="video" class="twelve cell video"
-                     ng-style="{'background-image': videoThumbUrl(document)}">
-                    <i>
-                        <svg class="icon-video" width="40" height="40">
-                            <use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use>
-                        </svg>
-                    </i>
+                <div class="img container video" ng-switch-when="video">
+                    <i><svg class="icon-video" width="40" height="40"><use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use></svg></i>
                 </div>
 
                 <i ng-switch-default class="[[content.role]]-large"></i>

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -29,7 +29,7 @@
                 </a>
             </legend>
 
-            <a class="container" ng-switch="content.role">
+            <a class="container [[content.role]]" ng-switch="content.role">
                 <!-- img format -->
                 <div ng-switch-when="img" class="twelve cell">
                     <div class="clip">
@@ -37,11 +37,16 @@
                     </div>
                 </div>
 
-                <div class="img container video" ng-switch-when="video">
+                <div class="img video" ng-switch-when="video">
                     <i><svg class="icon-video" width="40" height="40"><use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use></svg></i>
                 </div>
-
-                <i ng-switch-default class="[[content.role]]-large"></i>
+                <i ng-switch-when="doc" class="doc-large"></i>
+                <i ng-switch-when="pdf" class="pdf-large"></i>
+                <i ng-switch-when="spreadsheet" class="xls-large"></i>
+                <i ng-switch-when="presentation" class="ppt-large"></i>
+                <i ng-switch-when="audio" class="audio-large"></i>
+                <i ng-switch-when="folder" class="folder-large"></i>
+                <i ng-switch-default class="unknown-large"></i>
             </a>
         </explorer>
     </article>

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -40,13 +40,7 @@
                 <div class="img video" ng-switch-when="video">
                     <i><svg class="icon-video" width="40" height="40"><use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use></svg></i>
                 </div>
-                <i ng-switch-when="doc" class="doc-large"></i>
-                <i ng-switch-when="pdf" class="pdf-large"></i>
-                <i ng-switch-when="spreadsheet" class="xls-large"></i>
-                <i ng-switch-when="presentation" class="ppt-large"></i>
-                <i ng-switch-when="audio" class="audio-large"></i>
-                <i ng-switch-when="folder" class="folder-large"></i>
-                <i ng-switch-default class="unknown-large"></i>
+                <i ng-switch-default class="[[content.role]]-large"></i>
             </a>
         </explorer>
     </article>

--- a/src/main/resources/public/ts/core/enums/document-role.ts
+++ b/src/main/resources/public/ts/core/enums/document-role.ts
@@ -3,12 +3,9 @@ export enum DocumentRole {
     PPT = 'presentation',
     VIDEO = 'video',
     IMG = 'img',
-    OCTET_STEAM = 'octet-stream',
     AUDIO = 'audio',
     DOC = 'doc',
     PDF = 'pdf',
-    MARKDOWN = 'markdown',
-    MOODLE = 'moodle',
     UNKNOWN = 'unknown',
     FOLDER = 'folder'
 }

--- a/src/main/resources/public/ts/core/enums/document-role.ts
+++ b/src/main/resources/public/ts/core/enums/document-role.ts
@@ -1,14 +1,14 @@
 export enum DocumentRole {
+    XLS = 'spreadsheet',
+    PPT = 'presentation',
     VIDEO = 'video',
-    PDF = 'pdf',
-    UNKNOWN = 'unknown',
     IMG = 'img',
-    MARKDOWN = 'markdown',
-    DOC = 'doc',
-    MOODLE = 'moodle',
     OCTET_STEAM = 'octet-stream',
-    XLS = 'xls',
-    PPT = 'ppt',
     AUDIO = 'audio',
+    DOC = 'doc',
+    PDF = 'pdf',
+    MARKDOWN = 'markdown',
+    MOODLE = 'moodle',
+    UNKNOWN = 'unknown',
     FOLDER = 'folder'
 }

--- a/src/main/resources/public/ts/core/enums/document-role.ts
+++ b/src/main/resources/public/ts/core/enums/document-role.ts
@@ -6,5 +6,9 @@ export enum DocumentRole {
     MARKDOWN = 'markdown',
     DOC = 'doc',
     MOODLE = 'moodle',
-    OCTET_STEAM = 'octet-stream'
+    OCTET_STEAM = 'octet-stream',
+    XLS = 'xls',
+    PPT = 'ppt',
+    AUDIO = 'audio',
+    FOLDER = 'folder'
 }

--- a/src/main/resources/public/ts/models/nextcloud.folder.model.ts
+++ b/src/main/resources/public/ts/models/nextcloud.folder.model.ts
@@ -63,7 +63,9 @@ export class SyncDocument {
     }
 
     determineRole(): DocumentRole {
-        if (this.contentType) {
+        if (this.isFolder) {
+            return DocumentRole.FOLDER
+        } else if (this.contentType) {
             return NextcloudDocumentsUtils.determineRole(this.contentType);
         } else {
             return DocumentRole.UNKNOWN;
@@ -79,7 +81,13 @@ export class SyncDocument {
     }
 
     isEditable(): boolean {
-        return (<any>[DocumentRole.DOC, DocumentRole.PDF, DocumentRole.MARKDOWN, DocumentRole.OCTET_STEAM]).includes(this.role);
+        return (<any>[  DocumentRole.DOC,
+                        DocumentRole.PDF,
+                        DocumentRole.MARKDOWN,
+                        DocumentRole.OCTET_STEAM,
+                        DocumentRole.XLS,
+                        DocumentRole.PPT
+        ]).includes(this.role);
     }
     // create a folder with only one content (synchronized document) and its children all sync documents
     initParent(): SyncDocument {

--- a/src/main/resources/public/ts/models/nextcloud.folder.model.ts
+++ b/src/main/resources/public/ts/models/nextcloud.folder.model.ts
@@ -83,8 +83,6 @@ export class SyncDocument {
     isEditable(): boolean {
         return (<any>[  DocumentRole.DOC,
                         DocumentRole.PDF,
-                        DocumentRole.MARKDOWN,
-                        DocumentRole.OCTET_STEAM,
                         DocumentRole.XLS,
                         DocumentRole.PPT
         ]).includes(this.role);

--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -102,7 +102,7 @@ describe('NextcloudService', () => {
             path: "path2",
             size: 0,
             type: "folder",
-            role: "unknown",
+            role: "folder",
             editable: false
         }
 

--- a/src/main/resources/public/ts/utils/nextcloud-documents.utils.ts
+++ b/src/main/resources/public/ts/utils/nextcloud-documents.utils.ts
@@ -3,25 +3,10 @@ import {model} from "entcore";
 import {DocumentRole} from "../core/enums/document-role";
 
 export class NextcloudDocumentsUtils {
-    static typeMap: Map<string, DocumentRole> = new Map<string, DocumentRole>()
-
-        .set("image", DocumentRole.IMG)
-        .set("video", DocumentRole.VIDEO)
-        .set("audio", DocumentRole.AUDIO)
-        .set("presentation", DocumentRole.PPT)
-        .set("spreadsheet", DocumentRole.XLS)
-        .set("markdown", DocumentRole.MARKDOWN)
-        .set("doc", DocumentRole.DOC)
-        .set("pdf", DocumentRole.PDF)
-        .set("octet-stream", DocumentRole.OCTET_STEAM)
-        .set("moodle", DocumentRole.MOODLE);
-
-
     static determineRole(contentType: string): DocumentRole {
-        console.log(Array.from(this.typeMap));
-        for (let pattern of Array.from(this.typeMap.keys())) {
-            if (contentType.includes(pattern)) {
-                return this.typeMap.get(pattern);
+        for (let role in DocumentRole) {
+            if (contentType.includes(DocumentRole[role])) {
+                return <DocumentRole>DocumentRole[role];
             }
         }
         return DocumentRole.UNKNOWN;

--- a/src/main/resources/public/ts/utils/nextcloud-documents.utils.ts
+++ b/src/main/resources/public/ts/utils/nextcloud-documents.utils.ts
@@ -4,15 +4,21 @@ import {DocumentRole} from "../core/enums/document-role";
 
 export class NextcloudDocumentsUtils {
     static typeMap: Map<string, DocumentRole> = new Map<string, DocumentRole>()
+
+        .set("image", DocumentRole.IMG)
+        .set("video", DocumentRole.VIDEO)
+        .set("audio", DocumentRole.AUDIO)
+        .set("presentation", DocumentRole.PPT)
+        .set("spreadsheet", DocumentRole.XLS)
+        .set("markdown", DocumentRole.MARKDOWN)
         .set("doc", DocumentRole.DOC)
         .set("pdf", DocumentRole.PDF)
-        .set("markdown", DocumentRole.MARKDOWN)
         .set("octet-stream", DocumentRole.OCTET_STEAM)
-        .set("moodle", DocumentRole.MOODLE)
-        .set("image", DocumentRole.IMG)
-        .set("video", DocumentRole.VIDEO);
+        .set("moodle", DocumentRole.MOODLE);
+
 
     static determineRole(contentType: string): DocumentRole {
+        console.log(Array.from(this.typeMap));
         for (let pattern of Array.from(this.typeMap.keys())) {
             if (contentType.includes(pattern)) {
                 return this.typeMap.get(pattern);


### PR DESCRIPTION
## Describe your changes
Before this update, icons was all the same and not displayed according to file role.
## Checklist tests
- [x] List files with different type and see if each file is associated with the right icon depending on its role
## Issue ticket number and link
[ DRIV-68 ]
https://jira.support-ent.fr/browse/DRIV-68
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

