### PR TITLE
fix(onlyoffice): #DRIV-24 open doc located in root folder is now working

### DIFF
--- a/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud.service.test.ts
@@ -132,6 +132,33 @@ describe('NextcloudService', () => {
         });
     });
 
+    it('Test openNextcloudLink with root file', done => {
+        const syncDocument1: any = {
+            children: [],
+            contentType: "doc",
+            etag: "etag1",
+            favorite: 1,
+            fileId: 1,
+            isFolder: false,
+            name: "displayname1",
+            ownerDisplayName: "ownerDisplayName1",
+            path: "/",
+            size: 0,
+            type: "file",
+            role: "doc",
+            editable: true
+        }
+
+        const url = "url";
+        const fileId = 1;
+
+        window.open = jest.fn();
+        nextcloudService.openNextcloudLink(syncDocument1, url);
+        expect(window.open).toHaveBeenCalledTimes(1);
+        expect(window.open).toHaveBeenCalledWith(url + "/index.php/apps/files?dir=/&openfile=" + fileId);
+        done();
+    });
+
     it('Test getFile method with file', done => {
         const mock = new MockAdapter(axios);
 

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -20,8 +20,9 @@ export interface INextcloudService {
 
 export const nextcloudService: INextcloudService = {
     openNextcloudLink: (document: SyncDocument, nextcloudUrl: string): void => {
-        const url: string = document.path;
-        window.open(`${nextcloudUrl}/index.php/apps/files?dir=${url.substring(0, url.lastIndexOf('/'))}&openfile=${document.fileId}`);
+        const url: string = document.path.substring(0, document.path.lastIndexOf('/'));
+        const dir: string = url ? url : "/";
+        window.open(`${nextcloudUrl}/index.php/apps/files?dir=${dir}&openfile=${document.fileId}`);
     },
 
     getNextcloudUrl: async (): Promise<string> => {

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -20,8 +20,8 @@ export interface INextcloudService {
 
 export const nextcloudService: INextcloudService = {
     openNextcloudLink: (document: SyncDocument, nextcloudUrl: string): void => {
-        const url: string = document.path.includes("/") ? document.path.substring(0, document.path.lastIndexOf('/')) : "/";
-        const dir: string = url ? url : "/";
+        const url: string = document.path.substring(0, document.path.lastIndexOf('/'));
+        const dir: string = url.includes("/") ? url : "/";
         window.open(`${nextcloudUrl}/index.php/apps/files?dir=${dir}&openfile=${document.fileId}`);
     },
 

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -20,7 +20,7 @@ export interface INextcloudService {
 
 export const nextcloudService: INextcloudService = {
     openNextcloudLink: (document: SyncDocument, nextcloudUrl: string): void => {
-        const url: string = document.path.substring(0, document.path.lastIndexOf('/'));
+        const url: string = document.path.includes("/") ? document.path.substring(0, document.path.lastIndexOf('/')) : "/";
         const dir: string = url ? url : "/";
         window.open(`${nextcloudUrl}/index.php/apps/files?dir=${dir}&openfile=${document.fileId}`);
     },

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -20,8 +20,8 @@ export interface INextcloudService {
 
 export const nextcloudService: INextcloudService = {
     openNextcloudLink: (document: SyncDocument, nextcloudUrl: string): void => {
-        const url: string = document.path.substring(0, document.path.lastIndexOf('/'));
-        const dir: string = url.includes("/") ? url : "/";
+        const url: string = document.path.includes("/") ? document.path.substring(0, document.path.lastIndexOf('/')) : "";             ;
+        const dir: string = url ? url : "/";
         window.open(`${nextcloudUrl}/index.php/apps/files?dir=${dir}&openfile=${document.fileId}`);
     },
 

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -20,7 +20,7 @@ export interface INextcloudService {
 
 export const nextcloudService: INextcloudService = {
     openNextcloudLink: (document: SyncDocument, nextcloudUrl: string): void => {
-        const url: string = document.path.includes("/") ? document.path.substring(0, document.path.lastIndexOf('/')) : "";             ;
+        const url: string = document.path.includes("/") ? document.path.substring(0, document.path.lastIndexOf('/')) : "";
         const dir: string = url ? url : "/";
         window.open(`${nextcloudUrl}/index.php/apps/files?dir=${dir}&openfile=${document.fileId}`);
     },


### PR DESCRIPTION
## Describe your changes
Fixed url when open file located in nextloud root folder
## Checklist tests
- [x] Open file located in root
- [x] Open file located under a subfolder of root
## Issue ticket number and link
[ DRIV-24 ] 
https://jira.support-ent.fr/browse/DRIV-24
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

