### PR TITLE
fix(thumbnail): #DRIV-68 display thumbnail for images is working

### DIFF
--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/content/workspace-nextcloud-content.html
@@ -31,7 +31,7 @@
 
             <a class="container [[content.role]]" ng-switch="content.role">
                 <!-- img format -->
-                <div ng-switch-when="img" class="twelve cell">
+                <div ng-switch-when="image" class="twelve cell">
                     <div class="clip">
                         <img ng-src="[[vm.getFile(content)]]" alt="thumbnail" src="" width="117" height="115"/>
                     </div>

--- a/src/main/resources/public/ts/core/enums/document-role.ts
+++ b/src/main/resources/public/ts/core/enums/document-role.ts
@@ -2,7 +2,7 @@ export enum DocumentRole {
     XLS = 'spreadsheet',
     PPT = 'presentation',
     VIDEO = 'video',
-    IMG = 'img',
+    IMG = 'image',
     AUDIO = 'audio',
     DOC = 'doc',
     PDF = 'pdf',


### PR DESCRIPTION
## Describe your changes
Wrong role for images leading to bad front display. Now images are typed like "image".
## Checklist tests
- [x] List images and see the thumbnail
## Issue ticket number and link
[ DRIV-68 ]
https://jira.support-ent.fr/browse/DRIV-68
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

