### PR TITLE
fix(share): #DRIV-82 cancel file share does not delete file anymore

### DIFF
--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
@@ -80,7 +80,7 @@ export class ToolbarShareSnipletViewModel implements IViewModel {
                 this.vm.updateTree();
                 this.vm.safeApply();
             } catch (e) {
-                console.error((e));
+                console.error("Error while canceling share: " + e);
             }
             this.sharedElement = [];
         }

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
@@ -2,8 +2,8 @@ import {model, SharePayload, template, workspace} from "entcore";
 import {RootsConst} from "../../core/constants/roots.const";
 import {SyncDocument} from "../../models";
 import models = workspace.v2.models;
-import service = workspace.v2.service;
 import {WorkspaceEntcoreUtils} from "../../utils/workspace-entcore.utils";
+import {nextcloudService} from "../../services";
 
 interface IViewModel {
     copyingForShare: boolean;
@@ -76,7 +76,9 @@ export class ToolbarShareSnipletViewModel implements IViewModel {
     async onCancelShareElements(): Promise<void> {
         if (this.sharedElement.length) {
             try {
-                await service.deleteAll(this.sharedElement);
+                await nextcloudService.moveDocumentWorkspaceToCloud(model.me.userId, this.sharedElement.map(doc => doc._id), this.vm.parentDocument.path);
+                this.vm.updateTree();
+                this.vm.safeApply();
             } catch (e) {
                 console.error((e));
             }


### PR DESCRIPTION
## Describe your changes
Before this update, when using "share and not copy", the file was deleted if the action was cancelled. Now the file stays in the folder if the action is cancelled.
## Checklist tests
- [x] Cancel a "Share and not copy"
- [x] Use "Share and not copy" without cancelling  
- [x] Cancel a "Share and not copy" with multiple files
## Issue ticket number and link
[ DRIV-82 ]
https://jira.support-ent.fr/browse/DRIV-82
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

