### PR TITLE
fix(quota): #DRIV-74 update quota calculation method

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -145,6 +145,18 @@ public class DocumentsController extends ControllerHelper {
         }
     }
 
+    @Delete("/files/user/:userid/trash/delete")
+    @ApiDoc("delete trash API")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(OwnerFilter.class)
+    public void deleteTrash(HttpServerRequest request) {
+        UserUtils.getUserInfos(eb, request, user ->
+                userService.getUserSession(user.getUserId())
+                        .compose(documentsService::deleteTrash)
+                        .onSuccess(res -> renderJson(request, new JsonObject().put(Field.STATUS, Field.OK)))
+                        .onFailure(err -> renderError(request, new JsonObject().put(Field.MESSAGE, err.getMessage()))));
+    }
+
     @Put("/files/user/:userid/upload")
     @ApiDoc("Upload file")
     @SecuredAction(value = "", type = ActionType.RESOURCE)

--- a/src/main/java/fr/openent/nextcloud/core/constants/Field.java
+++ b/src/main/java/fr/openent/nextcloud/core/constants/Field.java
@@ -140,7 +140,8 @@ public class Field {
     public static final String COMMENTSUNREAD = "commentsUnread";
     public static final String OWNERDISPLAYNAME = "ownerDisplayName";
     public static final String SHARETYPE = "shareTypes";
-
+    public static final String TRASH = "trash";
+    public static final String TRASHBIN = "trashbin";
 
 
     private Field() {

--- a/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/DocumentsService.java
@@ -73,11 +73,18 @@ public interface DocumentsService {
     Future<JsonObject> moveDocument(UserNextcloud.TokenProvider userSession, String path, String destPath);
 
     /**
-     * delete documents
-     *
-     * @param userSession   User Session {@link UserNextcloud.TokenProvider}
-     * @param paths         list of paths / documents to delete
+     * method that delete trash
+     * @param   userSession     User Session {@link UserNextcloud.TokenProvider}
      */
+    Future<Void> deleteTrash(UserNextcloud.TokenProvider userSession);
+
+
+        /**
+         * delete documents
+         *
+         * @param userSession   User Session {@link UserNextcloud.TokenProvider}
+         * @param paths         list of paths / documents to delete
+         */
     Future<JsonObject> deleteDocuments(UserNextcloud.TokenProvider userSession, List<String> paths);
 
     /**

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultDocumentsService.java
@@ -299,6 +299,18 @@ public class DefaultDocumentsService implements DocumentsService {
     }
 
     /**
+     * method that delete trash
+     * @param   userSession     User Session {@link UserNextcloud.TokenProvider}
+     */
+    public Future<Void> deleteTrash(UserNextcloud.TokenProvider userSession) {
+        Promise<Void> promise = Promise.promise();
+        this.client.deleteAbs(nextcloudConfig.host() + nextcloudConfig.webdavEndpoint().replace(Field.FILES, "") + Field.TRASHBIN + "/" + userSession.userId() + "/" + Field.TRASH)
+                .basicAuthentication(userSession.userId(), userSession.token())
+                .send(responseAsync -> onDeleteDocumentHandler(responseAsync, promise));
+        return promise.future();
+    }
+
+    /**
      * Proceed async event after HTTP DELETE document API endpoint has been sent
      *
      * @param   responseAsync   HttpResponse of string depending on its state {@link AsyncResult}

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -13,5 +13,6 @@
   "nextcloud.documents.confirm.deletion": "Do you want to permanently delete these documents",
   "nextcloud.documents.deletion.confirmation": "Items have been permanently deleted.",
   "nextcloud.fail.upload": "Error while uploading files",
-  "file.too.large.upload": "File too large"
+  "file.too.large.upload": "File too large",
+  "workspace.definitive.delete.confirm.action": "Delete permanently"
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -13,5 +13,6 @@
   "nextcloud.documents.confirm.deletion": "Voulez-vous supprimer définitivement ces documents",
   "nextcloud.documents.deletion.confirmation": "Les éléments ont été définitivement supprimés.",
   "nextcloud.fail.upload": "Une erreur est survenue pendant le téléchargement des fichiers.",
-  "file.too.large.upload": "Fichier(s) trop volumineux"
+  "file.too.large.upload": "Fichier(s) trop volumineux",
+  "workspace.definitive.delete.confirm.action": "Supprimer définitivement"
 }

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/toolbar/workspace-nextcloud-toolbar-delete.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-content/toolbar/workspace-nextcloud-toolbar-delete.html
@@ -16,7 +16,7 @@
 
             <!-- delete -->
             <button class="nextcloud-button-confirm right-magnet" ng-click="vm.toolbar.deleteDocuments()">
-                <i18n>workspace.delete.confirm.action</i18n>
+                <i18n>workspace.definitive.delete.confirm.action</i18n>
             </button>
 
             <!-- cancel -->

--- a/src/main/resources/public/ts/models/nextcloud-user.model.ts
+++ b/src/main/resources/public/ts/models/nextcloud-user.model.ts
@@ -46,9 +46,15 @@ export class Quota {
         this.total = data.total / (1024 * 1024);
         this.relative = data.relative;
         this.quota = data.quota;
-        this.total = Math.round((this.total / 1024) * 100) / 100;
-        this.used = Math.round((this.used / 1024) * 100) / 100;
-        this.unit = 'Go';
+        if (this.total > 2000) {
+            this.total = Math.round((this.total / 1024) * 100) / 100;
+            this.used = Math.round((this.used / 1024) * 100) / 100;
+            this.unit = 'Go';
+        } else {
+            this.total = Math.round(this.total);
+            this.used = Math.round(this.used);
+            this.unit = 'Mo';
+        }
         return this;
     }
 }

--- a/src/main/resources/public/ts/models/nextcloud-user.model.ts
+++ b/src/main/resources/public/ts/models/nextcloud-user.model.ts
@@ -46,15 +46,9 @@ export class Quota {
         this.total = data.total / (1024 * 1024);
         this.relative = data.relative;
         this.quota = data.quota;
-        if (this.total > 2000) {
-            this.total = Math.round((this.total / 1024) * 100) / 100;
-            this.used = Math.round((this.used / 1024) * 100) / 100;
-            this.unit = 'Go';
-        } else {
-            this.total = Math.round(this.total);
-            this.used = Math.round(this.used);
-            this.unit = 'Mo';
-        }
+        this.total = Math.round((this.total / 1024) * 100) / 100;
+        this.used = Math.round((this.used / 1024) * 100) / 100;
+        this.unit = 'Go';
         return this;
     }
 }

--- a/src/main/resources/public/ts/services/nextcloud.service.ts
+++ b/src/main/resources/public/ts/services/nextcloud.service.ts
@@ -13,6 +13,7 @@ export interface INextcloudService {
     moveDocumentWorkspaceToCloud(userid: string, ids: Array<string>, cloudDocumentName?: string): Promise<AxiosResponse>;
     copyDocumentToWorkspace(userid: string, paths: Array<string>, parentId?: string): Promise<Array<models.Element>>;
     deleteDocuments(userid: string, path: Array<string>): Promise<AxiosResponse>;
+    deleteTrash(userid: string): Promise<AxiosResponse>;
     getFile(userid: string, fileName: string, path: string, contentType: string, isFolder?: boolean): string;
     getFiles(userid: string, path: string, files: Array<string>): string;
     createFolder(userid: string, folderPath: String): Promise<AxiosResponse>;
@@ -88,6 +89,10 @@ export const nextcloudService: INextcloudService = {
             urlParams.append('path', path);
         });
         return http.delete(`/nextcloud/files/user/${userid}/delete?${urlParams}`);
+    },
+
+    deleteTrash(userid: string): Promise<AxiosResponse> {
+        return http.delete(`/nextcloud/files/user/${userid}/trash/delete`);
     },
 
     getFile: (userid: string, fileName: string, path: string, contentType: string, isFolder: boolean = false): string => {

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -207,11 +207,14 @@ class ViewModel implements IViewModel {
 
     private processMoveTree(folderContent: any, document: SyncDocument, selectedFolderFromNextcloudTree: SyncDocument): void {
         if (folderContent.folder instanceof models.Element) {
+            const nextcloudController: any = this.getNextcloudTreeController();
             const filesToMove: Set<SyncDocument> = new Set(this.selectedDocuments).add(document);
             const filesPath: Array<string> = Array.from(filesToMove).map((file: SyncDocument) => file.path);
             if (filesPath.length) {
                 this.nextcloudService.moveDocumentNextcloudToWorkspace(model.me.userId, filesPath, folderContent.folder._id)
-                    .then(() => {
+                    .then(() => nextcloudController.nextcloudUserService.getUserInfo(model.me.userId))
+                    .then(userInfos => {
+                        nextcloudController.userInfo = userInfos;
                         return nextcloudService.listDocument(model.me.userId, selectedFolderFromNextcloudTree.path ?
                             selectedFolderFromNextcloudTree.path : null);
                     })
@@ -229,7 +232,7 @@ class ViewModel implements IViewModel {
                     });
             }
         } else {
-            this.processMoveToNextcloud(document, folderContent.folder, selectedFolderFromNextcloudTree);
+            this.processMoveToNextcloud(document, folderContent.folder, selectedFolderFromNextcloudTree)
         }
     }
 

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar-share.sniplet.ts
@@ -51,6 +51,10 @@ export class ToolbarShareSnipletViewModel implements IViewModel {
                 const pathTemplate: string = `../../../${RootsConst.template}/behaviours/sniplet-nextcloud-content/toolbar/share/share`;
                 this.vm.selectedDocuments = [];
                 template.open('workspace-nextcloud-toolbar-share', pathTemplate);
+            })
+            .then(this.vm.getNextcloudTreeController().nextcloudUserService.getUserInfo(model.me.userId))
+            .then(userInfo => {
+                this.vm.getNextcloudTreeController().userInfo = userInfo;
             });
     }
 

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-toolbar.sniplet.ts
@@ -135,8 +135,12 @@ export class ToolbarSnipletViewModel implements IViewModel {
 
     deleteDocuments(): void {
         const paths: Array<string> = this.vm.selectedDocuments.map((selectedDocument: SyncDocument) => selectedDocument.path);
+        const nextcloudTreeController = this.vm.getNextcloudTreeController();
         this.vm.nextcloudService.deleteDocuments(model.me.userId, paths)
-            .then(() => {
+            .then(() => this.vm.nextcloudService.deleteTrash(model.me.userId))
+            .then(() => nextcloudTreeController.nextcloudUserService.getUserInfo(model.me.userId))
+            .then(userInfos => {
+                nextcloudTreeController.userInfo = userInfos;
                 toasts.info("nextcloud.documents.deletion.confirmation");
                 return this.vm.nextcloudService.listDocument(model.me.userId, this.vm.parentDocument.path ?
                     this.vm.parentDocument.path : null);

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-upload-file.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-upload-file.sniplet.ts
@@ -57,7 +57,7 @@ export class UploadFileSnipletViewModel implements IViewModel {
 
     onValidImportFiles(): void {
         let selectedFolderFromNextcloudTree: SyncDocument = this.vm.getNextcloudTreeController()['selectedFolder'];
-        let nextcloudController: any = this.vm.getNextcloudTreeController();
+        const nextcloudController: any = this.vm.getNextcloudTreeController();
         this.vm.nextcloudService.uploadDocuments(model.me.userId, this.uploadedDocuments, selectedFolderFromNextcloudTree.path)
             .then(() => nextcloudController.nextcloudUserService.getUserInfo(model.me.userId))
             .then(userInfos => {

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-upload-file.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-upload-file.sniplet.ts
@@ -2,6 +2,7 @@ import {idiom as lang, model, notify} from "entcore";
 import {safeApply} from "../../utils/safe-apply.utils";
 import {AxiosError} from "axios";
 import {SyncDocument} from "../../models";
+import {Quota} from "../../models/nextcloud-user.model";
 
 declare let window: any;
 
@@ -56,17 +57,11 @@ export class UploadFileSnipletViewModel implements IViewModel {
 
     onValidImportFiles(): void {
         let selectedFolderFromNextcloudTree: SyncDocument = this.vm.getNextcloudTreeController()['selectedFolder'];
-        let userVm: any = this.vm.getNextcloudTreeController();
+        let nextcloudController: any = this.vm.getNextcloudTreeController();
         this.vm.nextcloudService.uploadDocuments(model.me.userId, this.uploadedDocuments, selectedFolderFromNextcloudTree.path)
-            .then(() => {
-                this.uploadedDocuments.forEach(file => {
-                    if (userVm.userInfo.quota.total * 1024 * 1024 > 2000) {
-                        userVm.userInfo.quota.used += Math.round((<File>file).size / (1000 * 1000)) / 1000;
-                    } else {
-                        userVm.userInfo.quota.used += Math.round((<File>file).size / 1000) / 1000;
-                    }
-                })
-                this.uploadedDocuments = [];
+            .then(() => nextcloudController.nextcloudUserService.getUserInfo(model.me.userId))
+            .then(userInfos => {
+                nextcloudController.userInfo = userInfos;
                 return this.vm.nextcloudService.listDocument(model.me.userId, this.vm.parentDocument.path ?
                     this.vm.parentDocument.path : null);
             })
@@ -85,7 +80,7 @@ export class UploadFileSnipletViewModel implements IViewModel {
                     notify.error(lang.translate('nextcloud.fail.upload'));
                 }
             })
-        this.lightbox.uploadFile = false;
+        this.toggleUploadFilesView(false);
         safeApply(this.scope);
     }
 


### PR DESCRIPTION
## Describe your changes
Now quota is updated with nextcloud server data and update each time a file is moved or deleted.
An other issue in the quota update was appening while deleting a file. On the ENT side, the delete is permanent because trash for nextcloud is not implemented, but trashbin exits on the nextcloud server. As the feature is not implemented yet, we decided to delete permanently (empty trashbin on server side) each time the user deletre a file. The is the reasons why a new API is implemented. The trash empty action was implemented in an other API in order to anticipate the trashbin feature.
API link: https://confluence.support-ent.fr/display/DRIV/Nextcloud+Documents+API#NextcloudDocumentsAPI-Emptytrash
Without this update, the user's quota was shortened because the trash counts in the user quota and the user had not tools top empty the trash from the ENT.
Also updated messages because when a file is deleted on nextcloud, it is deleted permanently. 
## Checklist tests
- [x] Delete a file and see if quota is updated
- [x] Move a file and see if the quota is update 
## Issue ticket number and link
[ DRIV-74 ]
https://jira.support-ent.fr/browse/DRIV-74
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

