### PR TITLE
feat(quota): #DRIV-99 add configurable quota value on create user

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Specific configuration that must be seen :
         "endpoint" : {
             "ocs-api": "${nextcloudOCSAPI}",
             "webdav-api": "${nextcloudWebdavAPI}"
-        }
+        },
+        "quota": "${nextcloudQuota}"
       }
 }
 </pre>
@@ -36,10 +37,14 @@ adminNextcloudPassword=${String}
 nextcloudHost=${String}
 nextcloudOCSAPI=${String}
 nextcloudWebdavAPI=${String}
+nextcloudQuota=${String}
 
 # ENDPOINT
 nextcloudOCSAPI=/ocs/v1.php
 nextcloudWebdavAPI=/remote.php/dav/files
+
+# Misc
+nextcloudQuota=2 GB
 </pre>
 
 

--- a/deployment/nextcloud/conf.j2
+++ b/deployment/nextcloud/conf.j2
@@ -26,6 +26,7 @@
             "ocs-api": "{{ nextcloudOCSAPI | default('/ocs/v1.php') }}",
             "webdav-api": "{{ nextcloudWebdavAPI | default('/remote.php/dav/files') }}"
         },
+        "quota": "{{ nextcloudQuota | default('2 GB') }}",
         "publicConf": {
             "xiti": {
                 "LIBELLE_SERVICE": {

--- a/deployment/nextcloud/conf.json.template
+++ b/deployment/nextcloud/conf.json.template
@@ -24,6 +24,7 @@
         "endpoint" : {
             "ocs-api": "${nextcloudOCSAPI}",
             "webdav-api": "${nextcloudWebdavAPI}"
-        }
+        },
+        "quota": "${nextcloudQuota}"
       }
     }

--- a/src/main/java/fr/openent/nextcloud/config/NextcloudConfig.java
+++ b/src/main/java/fr/openent/nextcloud/config/NextcloudConfig.java
@@ -9,6 +9,7 @@ public class NextcloudConfig {
     private final String password;
     private final String ocsEndpoint;
     private final String webdavEndpoint;
+    private final String quota;
 
     public NextcloudConfig(JsonObject config) {
         this.host = config.getString(Field.NEXTCLOUDHOST, null);
@@ -16,6 +17,7 @@ public class NextcloudConfig {
         this.password = config.getJsonObject(Field.ADMINCREDENTIAL, new JsonObject()).getString(Field.PASSWORD, null);
         this.ocsEndpoint = config.getJsonObject(Field.ENDPOINT, new JsonObject()).getString(Field.OCS_ENDPOINT_API, null);
         this.webdavEndpoint = config.getJsonObject(Field.ENDPOINT, new JsonObject()).getString(Field.WEBDAV_ENDPOINT_API, null);
+        this.quota = config.getString(Field.QUOTA, "2 GB");
     }
 
     public String host() {
@@ -29,4 +31,6 @@ public class NextcloudConfig {
     public String ocsEndpoint() { return this.ocsEndpoint; }
 
     public String webdavEndpoint() { return this.webdavEndpoint; }
+
+    public String quota() { return this.quota; }
 }

--- a/src/main/java/fr/openent/nextcloud/model/UserNextcloud.java
+++ b/src/main/java/fr/openent/nextcloud/model/UserNextcloud.java
@@ -1,5 +1,6 @@
 package fr.openent.nextcloud.model;
 
+import fr.openent.nextcloud.config.NextcloudConfig;
 import fr.openent.nextcloud.core.constants.Field;
 import io.vertx.core.json.JsonObject;
 
@@ -92,11 +93,20 @@ public class UserNextcloud {
         }
 
         public JsonObject toJSON() {
-            return new JsonObject()
+           return toJSON(new NextcloudConfig(new JsonObject()));
+        }
+
+        public JsonObject toJSON(NextcloudConfig nextcloudConfig) {
+            JsonObject bodyJson = new JsonObject()
                     .put(Field.USERID, this.userId)
                     .put(Field.DISPLAYNAMECAMEL, this.displayName)
-                    .put(Field.PASSWORD, this.password)
-                    .put(Field.QUOTA, "2 GB");
+                    .put(Field.PASSWORD, this.password);
+            if (nextcloudConfig.quota() == null || nextcloudConfig.quota().isEmpty()) {
+                bodyJson.put(Field.QUOTA, "2 GB");
+            } else {
+                bodyJson.put(Field.QUOTA, nextcloudConfig.quota());
+            }
+            return bodyJson;
         }
     }
 

--- a/src/main/java/fr/openent/nextcloud/service/impl/DefaultUserService.java
+++ b/src/main/java/fr/openent/nextcloud/service/impl/DefaultUserService.java
@@ -143,7 +143,7 @@ public class DefaultUserService implements UserService {
                 .putHeader(Field.OCS_API_REQUEST, String.valueOf(true))
                 .addQueryParam(Field.FORMAT, Field.JSON)
                 .as(BodyCodec.string(StandardCharsets.UTF_8.toString()))
-                .sendJsonObject(userBody.toJSON(), responseAsync -> proceedUserCreation(userBody, responseAsync, promise));
+                .sendJsonObject(userBody.toJSON(this.nextcloudConfig), responseAsync -> proceedUserCreation(userBody, responseAsync, promise));
         return promise.future();
     }
 
@@ -167,7 +167,7 @@ public class DefaultUserService implements UserService {
             } else {
                 JsonObject result = new JsonObject()
                         .put(Field.STATUS, Field.OK)
-                        .put(Field.DATA, userBody.toJSON());
+                        .put(Field.DATA, userBody.toJSON(this.nextcloudConfig));
                 promise.complete(result);
             }
         }


### PR DESCRIPTION
## Describe your changes

Aujourd'hui, quand il y a une création d'un utilisateur de nextcloud depuis l'ENT, son quota est à 2 GB
l'idée est de modifier son quota dynamiquement (en fonction de la configuration).

A rajouter dans la conf nextcloud : 

```
"config": {
   ...
   "endpoint" : {
            "ocs-api": "...",
            "webdav-api": "..."
        },
   "quota": "2 GB"
   ...
}
```

## Checklist tests

- Mettre une valeur "6 GB" dans la conf quota
- Aller dans l'espace doc avec un compte autorisé à accéder sur nextcloud qui aura son compte nextcloud generé avec 6 GB

## Issue ticket number and link

https://jira.support-ent.fr/browse/DRIV-99

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

