### PR TITLE
feat(i18n): change nextcloud.url.connect sentence

### DIFF
--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -9,7 +9,7 @@
   "folder.new.title": "Créer un dossier",
   "folder.new": "Créer un dossier",
   "workspace.folder.create": "Créer",
-  "nextcloud.url.connect": "Pour se connecter depuis votre téléphone ou votre ordinateur",
+  "nextcloud.url.connect": "Indiquez cette url en configuration Nextcloud pour accéder au service sur tous vos appareils",
   "nextcloud.documents.confirm.deletion": "Voulez-vous supprimer définitivement ces documents",
   "nextcloud.documents.deletion.confirmation": "Les éléments ont été définitivement supprimés.",
   "nextcloud.fail.upload": "Une erreur est survenue pendant le téléchargement des fichiers.",


### PR DESCRIPTION
## Describe your changes
Replace i18n nextcloud.url.connect sentence in fr.json file
## Checklist tests
When in workspace, click on "documents synchronisés", the sentence will appear above the nextcloud folders and must be "Indiquez cette url en configuration Nextcloud pour accéder au service sur tous vos appareils : http://nextcloud:8080/"
## Issue ticket number and link
[DRIV-50](https://jira.support-ent.fr/browse/DRIV-50)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

