### PR TITLE
feat(directive): #DRIV-100 fit progress bar quota value to nextcloud server user storage space

### DIFF
--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -15,5 +15,6 @@
   "nextcloud.fail.upload": "Une erreur est survenue pendant le téléchargement des fichiers.",
   "file.too.large.upload": "Fichier(s) trop volumineux",
   "error.user.info": "Erreur lors de la récupération des informations utilisateur",
-  "workspace.definitive.delete.confirm.action": "Supprimer définitivement"
+  "workspace.definitive.delete.confirm.action": "Supprimer définitivement",
+  "nextcloud.unlimited.space": "Espace illimité"
 }

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-folder/workspace-nextcloud-folder.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-folder/workspace-nextcloud-folder.html
@@ -21,7 +21,8 @@
             <h2>
                 <i18n>nextcloud.quota</i18n>
             </h2>
-            <progress-bar max="vm.userInfo.quota.total" filled="vm.userInfo.quota.used" unit="[[vm.userInfo.quota.unit]]"></progress-bar>
+            <progress-bar ng-if="vm.userInfo.quota.total !== 0" max="vm.userInfo.quota.total" filled="vm.userInfo.quota.used" unit="[[vm.userInfo.quota.unit]]"></progress-bar>
+            <span ng-if="vm.userInfo.quota.total === 0">Espace illimité</span>
         </div>
     </div>
 </div>

--- a/src/main/resources/public/template/behaviours/sniplet-nextcloud-folder/workspace-nextcloud-folder.html
+++ b/src/main/resources/public/template/behaviours/sniplet-nextcloud-folder/workspace-nextcloud-folder.html
@@ -22,7 +22,7 @@
                 <i18n>nextcloud.quota</i18n>
             </h2>
             <progress-bar ng-if="vm.userInfo.quota.total !== 0" max="vm.userInfo.quota.total" filled="vm.userInfo.quota.used" unit="[[vm.userInfo.quota.unit]]"></progress-bar>
-            <span ng-if="vm.userInfo.quota.total === 0">Espace illimité</span>
+            <span ng-if="vm.userInfo.quota.total === 0"><i18n>nextcloud.unlimited.space</i18n></span>
         </div>
     </div>
 </div>

--- a/src/main/resources/public/ts/models/__test__/nextcloud-user.model.test.ts
+++ b/src/main/resources/public/ts/models/__test__/nextcloud-user.model.test.ts
@@ -5,7 +5,8 @@ describe('NextcloudModel', () => {
     it('test Quota.build with big used', () => {
         const quota = new Quota().build({
             used: 1342177280,
-            total: 2147483648,
+            quota: 2147483648,
+            unit: 'Go'
         })
 
 
@@ -17,7 +18,8 @@ describe('NextcloudModel', () => {
     it('test Quota.build with small used', () => {
         const quota = new Quota().build({
             used: 85899345,
-            total: 2147483648,
+            quota: 2147483648,
+            unit: 'Go'
         })
 
         expect(quota.total).toEqual(2);
@@ -28,7 +30,8 @@ describe('NextcloudModel', () => {
     it('test Quota.build with less than 2000 Mo', () => {
         const quota = new Quota().build({
             used: 1200312736,
-            total: 1610612736,
+            quota: 1610612736,
+            unit: 'Mo'
         })
 
 

--- a/src/main/resources/public/ts/models/__test__/nextcloud-user.model.test.ts
+++ b/src/main/resources/public/ts/models/__test__/nextcloud-user.model.test.ts
@@ -4,16 +4,11 @@ describe('NextcloudModel', () => {
 
     it('test Quota.build with big used', () => {
         const quota = new Quota().build({
-            free: 805306368,
             used: 1342177280,
             total: 2147483648,
-            relative: 12.42,
-            quota: 2147483648,
         })
 
-        expect(quota.free).toEqual(805306368);
-        expect(quota.quota).toEqual(2147483648);
-        expect(quota.relative).toEqual(12.42);
+
         expect(quota.total).toEqual(2);
         expect(quota.unit).toEqual('Go');
         expect(quota.used).toEqual(1.25);
@@ -21,16 +16,10 @@ describe('NextcloudModel', () => {
 
     it('test Quota.build with small used', () => {
         const quota = new Quota().build({
-            free: 2061584303,
             used: 85899345,
             total: 2147483648,
-            relative: 12.42,
-            quota: 2147483648,
         })
 
-        expect(quota.free).toEqual(2061584303);
-        expect(quota.quota).toEqual(2147483648);
-        expect(quota.relative).toEqual(12.42);
         expect(quota.total).toEqual(2);
         expect(quota.unit).toEqual('Go');
         expect(quota.used).toEqual(0.08);
@@ -38,16 +27,11 @@ describe('NextcloudModel', () => {
 
     it('test Quota.build with less than 2000 Mo', () => {
         const quota = new Quota().build({
-            free: 410300000,
             used: 1200312736,
             total: 1610612736,
-            relative: 12.42,
-            quota: 1610612736,
         })
 
-        expect(quota.free).toEqual(410300000);
-        expect(quota.quota).toEqual(1610612736);
-        expect(quota.relative).toEqual(12.42);
+
         expect(quota.total).toEqual(1536);
         expect(quota.unit).toEqual('Mo');
         expect(quota.used).toEqual(1145);

--- a/src/main/resources/public/ts/models/nextcloud-user.model.ts
+++ b/src/main/resources/public/ts/models/nextcloud-user.model.ts
@@ -33,19 +33,14 @@ export class UserNextcloud {
 }
 
 export class Quota {
-    free: string;
     used: number;
     total: number;
-    relative: number;
-    quota: number;
     unit: string;
 
+
     build(data: any): Quota {
-        this.free = data.free;
         this.used = data.used / (1024 * 1024);
-        this.total = data.total / (1024 * 1024);
-        this.relative = data.relative;
-        this.quota = data.quota;
+        this.total = data.quota / (1024 * 1024);
         if (this.total > 2000) {
             this.total = Math.round((this.total / 1024) * 100) / 100;
             this.used = Math.round((this.used / 1024) * 100) / 100;

--- a/src/main/resources/public/ts/services/__test__/nextcloud-user.service.test.ts
+++ b/src/main/resources/public/ts/services/__test__/nextcloud-user.service.test.ts
@@ -34,7 +34,7 @@ describe('NextcloudUserService', () => {
         const userId = "userId";
 
         const quota: any = {
-            free: "free", quota: 0, relative: 0, total: 0, unit: "Mo", used: 0
+            total: 0, unit: "Mo", used: 0
         }
         const result: any = {
             displayName: 0,


### PR DESCRIPTION
## Describe your changes
The progress bar directive which displays the quota of user's space allocation used the data.total number send by OCS nextcloud API. But a percentage of error was added to this value which made the compute false. For example, if the user had 10 GB of storage, the API sent 8152707889 bytes (for the total) and then the progress bar displayed 7.7 Go because of the calcultation (this.total = data.total/ (1024 * 1024)).
Instead, i use data.quota value which represents better the user's storage. (this.total = data.quota / (1024 * 1024));
Moreover, if user has illimited capacity, the directive is replaced by a span tag to display "Espace illimité".
Finally, the model nextcloud-user.model.ts was changed and quota properties like "free", "relative" and "quota" were delated because unused by the DOM props (seen with Jin).
## Checklist tests
Choose a storage capacity in nextcloud server and check if the storage number corresponds in the progressBar value in "Espace documentaire" / "Documents synchronisés"
## Issue ticket number and link
[DRIV-100](https://jira.support-ent.fr/browse/DRIV-100)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

