### PR TITLE
feat(download): change zip file name when downloading from within a folder

### DIFF
--- a/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
+++ b/src/main/java/fr/openent/nextcloud/controller/DocumentsController.java
@@ -92,9 +92,8 @@ public class DocumentsController extends ControllerHelper {
                     userService.getUserSession(user.getUserId())
                             .compose(userSession -> documentsService.getFiles(userSession, path, files))
                             .onSuccess(fileResponse -> {
-                                String pathName = path.equals("/") ? Field.ARCHIVE : path;
                                 HttpServerResponse resp = request.response();
-                                resp.putHeader("Content-Disposition", "attachment; filename=\"" + pathName + ".zip\"");
+                                resp.putHeader("Content-Disposition", "attachment; filename=\"" + Field.ARCHIVE + ".zip\"");
                                 resp.putHeader("Content-Type", "application/octet-stream");
                                 resp.putHeader("Content-Description", "File Transfer");
                                 resp.putHeader("Content-Transfer-Encoding", "binary");


### PR DESCRIPTION
## Describe your changes
When selecting files inside a folder and click on download button, the zip files used to take "folderName.zip" name.
Now the zip file is called archive.zip
## Checklist tests
Go ton "document synchronisés" and try to download multiple files inside a specific folder. The generated zip file should be called "archive.zip"
## Issue ticket number and link
[DRIV-97](https://jira.support-ent.fr/browse/DRIV-97)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

