### PR TITLE
feat(preference): #DRIV-102 create user preference for nextcloud view 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/core-js": "0.9.42",
     "@types/jest": "^22.2.0",
     "@types/jquery": "^2.0.34",
-    "axios-mock-adapter": "^1.19.0",
+    "axios-mock-adapter": "1.21.2",
     "gulp-append-prepend": "^1.0.8",
     "jest": "^24.7.1",
     "jest-environment-node": "^23.0.0",

--- a/src/main/resources/public/ts/shared/services/index.ts
+++ b/src/main/resources/public/ts/shared/services/index.ts
@@ -1,0 +1,1 @@
+export * from './nextcloud.preferences';

--- a/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
+++ b/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
@@ -1,0 +1,92 @@
+import {ViewMode} from "../../core/enums/view-mode";
+import {Me, notify} from "entcore";
+
+
+export type NextcloudPreference = {
+    viewMode: ViewMode;
+}
+
+export class Preference {
+    private _viewMode: ViewMode;
+
+    get viewMode(): ViewMode {
+        return this._viewMode;
+    }
+
+    set viewMode(viewMode : ViewMode) {
+        this._viewMode = viewMode;
+    }
+
+    async init(): Promise<void> {
+        try {
+            // fetch nextcloud preference from Me
+            let preference: NextcloudPreference = Me.preferences['nextcloud'];
+            if (this.isEmpty(preference)) {
+                preference = await Me.preference('nextcloud');
+                // I have no pref, must init and save by default
+                if (this.isEmpty(preference)) {
+                    // init default
+                    preference.viewMode = ViewMode.ICONS;
+
+                    // persist for the first time my nextcloud preference
+                    await this.updatePreference(preference);
+                }
+            }
+            this.setProperties(preference);
+        } catch (e) {
+            notify.error('nextcloud.preferences.init.error');
+            throw e;
+        }
+    }
+
+    async updatePreference(preference: NextcloudPreference): Promise<void> {
+        Me.preferences.nextcloud = preference;
+        await Me.savePreference('nextcloud');
+    }
+
+    private setProperties(preference: NextcloudPreference): void {
+        this._viewMode = preference.viewMode;
+    }
+
+    private isEmpty(preference: NextcloudPreference): boolean {
+        return !preference || !Object.keys(preference).length;
+    }
+
+    // async initPreference(): Promise<any> {
+    //     let pref;
+    //     try {
+    //          pref = await Me.preference('nextcloud');
+    //          this._viewMode =
+    //     } catch (e) {
+    //         console.log(e + "nextcloud.preference.viewMode.initPreference")
+    //         pref = undefined;
+    //     }
+    //
+    //     if (typeof pref === 'undefined') {
+    //         Me.preferences.nextcloud = {"viewMode" : ViewMode.ICONS};
+    //         Me.savePreference('nextcloud');
+    //     }
+    //         return await Me.preference('nextcloud');
+    //     // Me.preference('nextcloud')
+    //     //     .then(res => res)
+    //     //     .then(res => res)
+    //     //     .then(res => res)
+    //     //     .catch(async() =>{
+    //     //         Me.preferences.nextcloud = {"viewMode" : ViewMode.ICONS};
+    //     //         await Me.savePreference('nextcloud');
+    //     //         return await Me.preference('nextcloud');
+    //     //     })
+    // }
+    //
+    //
+    // async updatePreference(value: ViewMode): Promise<void> {
+    //     Me.preference(Preferences.NEXTCLOUD)
+    //         .then(async obj => {
+    //             obj = {...obj};
+    //             obj.viewMode = value;
+    //             Me.preferences[Preferences.NEXTCLOUD] = obj;
+    //             await Me.savePreference(Preferences.NEXTCLOUD);
+    //         })
+    // }
+
+}

--- a/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
+++ b/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
@@ -51,42 +51,5 @@ export class Preference {
     private isEmpty(preference: NextcloudPreference): boolean {
         return !preference || !Object.keys(preference).length;
     }
-
-    // async initPreference(): Promise<any> {
-    //     let pref;
-    //     try {
-    //          pref = await Me.preference('nextcloud');
-    //          this._viewMode =
-    //     } catch (e) {
-    //         console.log(e + "nextcloud.preference.viewMode.initPreference")
-    //         pref = undefined;
-    //     }
-    //
-    //     if (typeof pref === 'undefined') {
-    //         Me.preferences.nextcloud = {"viewMode" : ViewMode.ICONS};
-    //         Me.savePreference('nextcloud');
-    //     }
-    //         return await Me.preference('nextcloud');
-    //     // Me.preference('nextcloud')
-    //     //     .then(res => res)
-    //     //     .then(res => res)
-    //     //     .then(res => res)
-    //     //     .catch(async() =>{
-    //     //         Me.preferences.nextcloud = {"viewMode" : ViewMode.ICONS};
-    //     //         await Me.savePreference('nextcloud');
-    //     //         return await Me.preference('nextcloud');
-    //     //     })
-    // }
-    //
-    //
-    // async updatePreference(value: ViewMode): Promise<void> {
-    //     Me.preference(Preferences.NEXTCLOUD)
-    //         .then(async obj => {
-    //             obj = {...obj};
-    //             obj.viewMode = value;
-    //             Me.preferences[Preferences.NEXTCLOUD] = obj;
-    //             await Me.savePreference(Preferences.NEXTCLOUD);
-    //         })
-    // }
-
+    
 }

--- a/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
+++ b/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
@@ -20,16 +20,14 @@ export class Preference {
     async init(): Promise<void> {
         try {
             // fetch nextcloud preference from Me
-            let preference: NextcloudPreference = Me.preferences['nextcloud'];
-            if (this.isEmpty(preference)) {
-                preference = await Me.preference('nextcloud');
-                // I have no pref, must init and save by default
-                if (this.isEmpty(preference)) {
-                    // init default
-                    preference.viewMode = ViewMode.ICONS;
-                    // persist for the first time my nextcloud preference
-                    await this.updatePreference(preference);
-                }
+            let preference = await Me.preference('nextcloud');
+            // Check on nextcloud preferences AND nextcloud viewMode preferences
+            if (this.isEmpty(preference) || !preference.viewMode) {
+                // If no view mode, we set it with default value
+                preference.viewMode = ViewMode.ICONS;
+                // persist for the first time my nextcloud preference
+                await this.updatePreference(preference);
+
             }
             this.setProperties(preference);
         } catch (e) {

--- a/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
+++ b/src/main/resources/public/ts/shared/services/nextcloud.preferences.ts
@@ -27,7 +27,6 @@ export class Preference {
                 if (this.isEmpty(preference)) {
                     // init default
                     preference.viewMode = ViewMode.ICONS;
-
                     // persist for the first time my nextcloud preference
                     await this.updatePreference(preference);
                 }
@@ -41,7 +40,13 @@ export class Preference {
 
     async updatePreference(preference: NextcloudPreference): Promise<void> {
         Me.preferences.nextcloud = preference;
-        await Me.savePreference('nextcloud');
+        try {
+            await Me.savePreference('nextcloud');
+            this.setProperties(preference);
+        } catch(e) {
+            notify.error('nextcloud.preferences.updatepreference.error');
+            throw e;
+        }
     }
 
     private setProperties(preference: NextcloudPreference): void {

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -13,7 +13,7 @@ import models = workspace.v2.models;
 import {NextcloudViewList} from "./workspace-nextcloud-view-list.sniplet";
 import {NextcloudViewIcons} from "./workspace-nextcloud-view-icons.sniplet";
 import {NextcloudPreference, Preference} from "../../shared/services/nextcloud.preferences";
-import models = workspace.v2.models;
+
 
 declare let window: any;
 

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -12,7 +12,7 @@ import {ViewMode} from "../../core/enums/view-mode";
 import models = workspace.v2.models;
 import {NextcloudViewList} from "./workspace-nextcloud-view-list.sniplet";
 import {NextcloudViewIcons} from "./workspace-nextcloud-view-icons.sniplet";
-import {NextcloudPreference, Preference} from "../../shared/services/nextcloud.preferences";
+import {NextcloudPreference, Preference} from "../../shared/services";
 
 
 declare let window: any;
@@ -80,7 +80,6 @@ class ViewModel implements IViewModel {
         this.nextcloudUrl = null;
         this.selectedDocuments = new Array<SyncDocument>();
         this.nextcloudPreference = new Preference();
-
         // on init we first sync its main folder content
         Promise.all([this.initDocumentsContent(nextcloudService, scope),
             nextcloudService.getNextcloudUrl(), this.nextcloudPreference.init()])

--- a/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/content/workspace-nextcloud-content.sniplet.ts
@@ -1,4 +1,4 @@
-import {angular, Behaviours, idiom as lang, model, template, workspace} from "entcore";
+import {angular, Behaviours, idiom as lang, model, Me, template, workspace} from "entcore";
 import {NEXTCLOUD_APP} from "../../nextcloud.behaviours";
 import {Subscription} from "rxjs";
 import {Draggable, SyncDocument} from "../../models";
@@ -12,6 +12,8 @@ import {ViewMode} from "../../core/enums/view-mode";
 import models = workspace.v2.models;
 import {NextcloudViewList} from "./workspace-nextcloud-view-list.sniplet";
 import {NextcloudViewIcons} from "./workspace-nextcloud-view-icons.sniplet";
+import {NextcloudPreference, Preference} from "../../shared/services/nextcloud.preferences";
+import models = workspace.v2.models;
 
 declare let window: any;
 
@@ -22,23 +24,29 @@ interface IViewModel {
     safeApply(): void;
 
     initDraggable(): void;
-    onSelectContent(document: SyncDocument): void;
-    onOpenContent(document: SyncDocument): void;
-    getFile(document: SyncDocument): string;
-    nextcloudUrl: string;
 
+    onSelectContent(document: SyncDocument): void;
+
+    onOpenContent(document: SyncDocument): void;
+
+    getFile(document: SyncDocument): string;
+
+    nextcloudUrl: string;
     draggable: Draggable;
     lockDropzone: boolean;
     parentDocument: SyncDocument;
     documents: Array<SyncDocument>;
     selectedDocuments: Array<SyncDocument>;
     checkboxSelectAll: boolean;
+
     // drag & drop action
     moveDocument(element: any, document: SyncDocument): Promise<void>;
 
     // dropzone
     isDropzoneEnabled(): boolean;
+
     canDropOnFolder(): boolean;
+
     onCannotDropFile(): void;
 }
 
@@ -61,6 +69,7 @@ class ViewModel implements IViewModel {
     selectedDocuments: Array<SyncDocument>;
     isLoaded: boolean;
     checkboxSelectAll: boolean;
+    nextcloudPreference: Preference;
 
     constructor(scope, nextcloudService: INextcloudService) {
         this.isLoaded = false;
@@ -70,12 +79,13 @@ class ViewModel implements IViewModel {
         this.parentDocument = null;
         this.nextcloudUrl = null;
         this.selectedDocuments = new Array<SyncDocument>();
-
-        this.changeViewMode(ViewMode.ICONS);
+        this.nextcloudPreference = new Preference();
 
         // on init we first sync its main folder content
-        Promise.all([this.initDocumentsContent(nextcloudService, scope), nextcloudService.getNextcloudUrl()])
+        Promise.all([this.initDocumentsContent(nextcloudService, scope),
+            nextcloudService.getNextcloudUrl(), this.nextcloudPreference.init()])
             .then(([_, url]) => {
+                this.changeViewMode(this.nextcloudPreference.viewMode);
                 this.nextcloudUrl = url;
                 this.isLoaded = true;
                 safeApply(scope);
@@ -295,7 +305,11 @@ class ViewModel implements IViewModel {
         return template.contains('documents-content', pathTemplate);
     }
 
-    changeViewMode(mode: ViewMode): void {
+
+    async changeViewMode(mode: ViewMode): Promise<void> {
+        let preference: NextcloudPreference = Me.preferences['nextcloud'];
+        preference.viewMode = mode;
+        await this.nextcloudPreference.updatePreference(preference);
         const pathTemplate = `../../../${RootsConst.template}/behaviours/sniplet-nextcloud-content/content/views/${mode}`;
         this.documents.forEach(document => document.selected = false);
         this.selectedDocuments = [];


### PR DESCRIPTION
## Describe your changes
In workspace, the default view for nextcloud ("documents synchonisés") is the ICON one. Now, when the user switches in LIST view, this action sets a "viewMode" preference to store the view and then he can switch from "dossier partagés" to nextcloud and the choosen view remains the same. It also works when he gets back to the icon view. 

Update Axios mock-adapter to avoid test errors (has no default export) in dev mode.
## Checklist tests
In workspace, go to "documents synchronisés", change the view mode with the button on the right, then click on "documents partagés". If you come back to "documents synchronisés", the view you had chosen is still the same. You can try it by refreshing the browser too. 
## Issue ticket number and link
[DRIV-102](https://jira.support-ent.fr/browse/DRIV-102)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

